### PR TITLE
refactor: Centralize state management with Svelte stores

### DIFF
--- a/src/stores/bookStore.ts
+++ b/src/stores/bookStore.ts
@@ -1,0 +1,27 @@
+import { writable, derived, type Writable } from 'svelte/store'
+import type { Book } from '../lib/types/book'
+
+// Book state store
+export const book: Writable<Book | null> = writable(null)
+
+// Chapter selection state (Map of chapter id -> boolean)
+export const selectedChapters = writable(new Map<string, boolean>())
+
+// Generated audio state (Map of chapter id -> {url, blob})
+export const generatedAudio = writable(new Map<string, { url: string; blob: Blob }>())
+
+// Helper to get selected chapter IDs
+export const selectedChapterIds = derived(selectedChapters, ($selectedChapters) => {
+  return Array.from($selectedChapters.entries())
+    .filter(([_, selected]) => selected)
+    .map(([id]) => id)
+})
+
+// Helper to get selected chapters with full data
+export const selectedChaptersWithData = derived(
+  [book, selectedChapters],
+  ([$book, $selectedChapters]) => {
+    if (!$book) return []
+    return $book.chapters.filter((ch) => $selectedChapters.get(ch.id))
+  }
+)

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -1,0 +1,43 @@
+import { writable } from 'svelte/store'
+
+const APP_THEME_KEY = 'app_theme'
+
+export type Theme = 'light' | 'dark'
+
+// Check for system preference in browser
+function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'light'
+
+  try {
+    const saved = localStorage.getItem(APP_THEME_KEY)
+    if (saved === 'dark' || saved === 'light') {
+      return saved
+    }
+    // Default to system preference
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark'
+    }
+  } catch (e) {
+    console.warn('Failed to load theme from localStorage:', e)
+  }
+
+  return 'light'
+}
+
+export const appTheme = writable<Theme>(getInitialTheme())
+
+// Persist theme changes to localStorage
+if (typeof window !== 'undefined') {
+  appTheme.subscribe((theme) => {
+    try {
+      localStorage.setItem(APP_THEME_KEY, theme)
+      document.body.setAttribute('data-theme', theme)
+    } catch (e) {
+      console.warn('Failed to save theme to localStorage:', e)
+    }
+  })
+}
+
+export function toggleTheme() {
+  appTheme.update((current) => (current === 'light' ? 'dark' : 'light'))
+}

--- a/src/stores/ttsStore.ts
+++ b/src/stores/ttsStore.ts
@@ -1,0 +1,50 @@
+import { writable, type Writable } from 'svelte/store'
+
+// Storage keys
+const VOICE_KEY = 'audiobook_voice'
+const QUANT_KEY = 'audiobook_quantization'
+const DEVICE_KEY = 'audiobook_device'
+const MODEL_KEY = 'audiobook_model'
+
+// Type definitions
+export type Quantization = 'fp32' | 'fp16' | 'q8' | 'q4' | 'q4f16'
+export type Device = 'auto' | 'wasm' | 'webgpu' | 'cpu'
+export type TTSModel = 'kokoro' | 'piper'
+
+// Helper to create a localStorage-synced writable store
+function persistedWritable<T>(key: string, defaultValue: T): Writable<T> {
+  let initialValue = defaultValue
+
+  // Load from localStorage in browser
+  if (typeof window !== 'undefined') {
+    try {
+      const stored = localStorage.getItem(key)
+      if (stored) {
+        initialValue = JSON.parse(stored) as T
+      }
+    } catch (e) {
+      console.warn(`Failed to load ${key} from localStorage:`, e)
+    }
+  }
+
+  const store = writable<T>(initialValue)
+
+  // Subscribe to changes and persist to localStorage
+  if (typeof window !== 'undefined') {
+    store.subscribe((value) => {
+      try {
+        localStorage.setItem(key, JSON.stringify(value))
+      } catch (e) {
+        console.warn(`Failed to save ${key} to localStorage:`, e)
+      }
+    })
+  }
+
+  return store
+}
+
+// TTS configuration stores with localStorage persistence
+export const selectedVoice = persistedWritable<string>(VOICE_KEY, 'af_heart')
+export const selectedQuantization = persistedWritable<Quantization>(QUANT_KEY, 'q8')
+export const selectedDevice = persistedWritable<Device>(DEVICE_KEY, 'auto')
+export const selectedModel = persistedWritable<TTSModel>(MODEL_KEY, 'kokoro')


### PR DESCRIPTION
## Summary
This PR refactors state management in App.svelte by extracting all state into dedicated Svelte stores, addressing [issue #24](https://github.com/Cabeda/audiobook-generator/issues/24).

## Changes

### New Store Modules
- **bookStore.ts**: Manages book data, chapter selection, and generated audio
- **ttsStore.ts**: Manages TTS settings (voice, quantization, device, model) with automatic localStorage persistence
- **themeStore.ts**: Manages app theme with localStorage persistence and system preference detection

### App.svelte Refactoring
- ✅ Removed all `$state` declarations (book, selectedMap, generated, TTS settings, theme)
- ✅ Removed `onMount` and `$effect` hooks
- ✅ Removed manual localStorage read/write logic (~80 lines of boilerplate)
- ✅ Simplified event handlers to directly update stores
- ✅ Reduced file size from 409 to 333 lines (-76 lines, -18.6%)

### Benefits
- **Centralized state management**: All app state is now in stores
- **Automatic persistence**: TTS settings and theme automatically saved to localStorage
- **Better separation of concerns**: State logic separated from UI logic
- **Easier to test**: Stores can be tested independently
- **Reusable**: Stores can be imported and used by any component

## Verification
- ✅ Build passes successfully
- ✅ All tests pass (1 pre-existing failure unrelated to this change)
- ✅ No breaking changes to component APIs

Closes #24