### PR TITLE
fix: Remove unused CSS selector

### DIFF
--- a/src/components/ChapterItem.svelte
+++ b/src/components/ChapterItem.svelte
@@ -401,7 +401,7 @@
     color: var(--text-color);
   }
 
-  .action-btn.disabled {
+  .action-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
     background: var(--surface-color);


### PR DESCRIPTION
## Summary

Fixes unused CSS selector warning in ChapterItem.svelte.

### Changes

- Changed `.action-btn.disabled` class selector to `:disabled` pseudo-class
- The component uses the HTML `disabled` attribute on buttons, not a `.disabled` class

### Verification

- Build passes
- Lint passes (except pre-existing warnings)