### PR TITLE
fix: Add pnpm-lock.yaml to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,5 +6,6 @@ playwright-report
 test-results
 coverage
 package-lock.json
+pnpm-lock.yaml
 *.min.js
 *.min.css


### PR DESCRIPTION
## Summary

Fixes `pnpm run lint` failing due to Prettier trying to format the pnpm lockfile.

### Problem

The lint command was failing with:
```
[warn] pnpm-lock.yaml
[warn] Code style issues found in the above file.
```

### Solution

Added `pnpm-lock.yaml` to `.prettierignore` alongside the existing `package-lock.json`.

### Verification

- `pnpm run lint` now passes (only shows warnings, no errors)