### PR TITLE
fix: TypeScript errors in IndexedDB error handlers

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,5 +6,6 @@ playwright-report
 test-results
 coverage
 package-lock.json
+pnpm-lock.yaml
 *.min.js
 *.min.css

--- a/src/lib/libraryDB.ts
+++ b/src/lib/libraryDB.ts
@@ -286,7 +286,7 @@ export async function updateChapterLanguage(
           putRequest.onerror = (event) =>
             reject(
               new Error(
-                `Failed to save chapter language: ${event.target?.error?.message || 'Unknown error'}`
+                `Failed to save chapter language: ${(event.target as IDBRequest)?.error?.message || 'Unknown error'}`
               )
             )
         } else {
@@ -322,7 +322,7 @@ export async function updateBookLanguage(bookId: number, language: string): Prom
         putRequest.onerror = (event) =>
           reject(
             new Error(
-              `Failed to save book language: ${event.target?.error?.message || 'Unknown error'}`
+              `Failed to save book language: ${(event.target as IDBRequest)?.error?.message || 'Unknown error'}`
             )
           )
       } else {
@@ -361,7 +361,7 @@ export async function updateChapterModel(
           putRequest.onerror = (event) =>
             reject(
               new Error(
-                `Failed to save chapter model: ${event.target?.error?.message || 'Unknown error'}`
+                `Failed to save chapter model: ${(event.target as IDBRequest)?.error?.message || 'Unknown error'}`
               )
             )
         } else {
@@ -403,7 +403,7 @@ export async function updateChapterVoice(
           putRequest.onerror = (event) =>
             reject(
               new Error(
-                `Failed to save chapter voice: ${event.target?.error?.message || 'Unknown error'}`
+                `Failed to save chapter voice: ${(event.target as IDBRequest)?.error?.message || 'Unknown error'}`
               )
             )
         } else {


### PR DESCRIPTION
## Summary

Fixes `pnpm run type-check` failing with TS2339 errors.

### Problem

TypeScript was reporting 4 errors in `src/lib/libraryDB.ts`:
```
Property 'error' does not exist on type 'EventTarget'.
```

This was because `event.target` in IndexedDB `onerror` handlers is actually an `IDBRequest`, but TypeScript types it as the base `EventTarget`.

### Solution

Cast `event.target` to `IDBRequest` in all 4 affected error handlers:
```typescript
(event.target as IDBRequest)?.error?.message
```

Also includes the `pnpm-lock.yaml` to `.prettierignore` fix (if not already merged via #85).

### Verification

- `pnpm run type-check` passes
- `pnpm run lint` passes
- `pnpm run build` passes