### PR TITLE
feat: add KittenTTS browser-native TTS model

### DIFF
--- a/e2e/kittentts.spec.ts
+++ b/e2e/kittentts.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * KittenTTS E2E test
+ *
+ * Generates a chapter audio file using KittenTTS and validates:
+ * 1. The download is triggered with a .wav filename
+ * 2. The WAV file has a valid RIFF header
+ * 3. The audio duration is > 1 second (non-trivial content)
+ * 4. The audio is not silent (RMS > threshold)
+ * 5. Duration is proportional to text length (content sanity check)
+ */
+
+import { test, expect } from '@playwright/test'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+import process from 'node:process'
+
+const SHORT_EPUB = join(process.cwd(), 'books', 'test-short.epub')
+
+// ── WAV validation helpers ────────────────────────────────────────────────────
+
+function parseWavHeader(buf: Buffer) {
+  const riff = buf.toString('ascii', 0, 4)
+  if (riff !== 'RIFF') throw new Error(`Not a WAV file (got '${riff}')`)
+  const numChannels = buf.readUInt16LE(22)
+  const sampleRate = buf.readUInt32LE(24)
+  const bitsPerSample = buf.readUInt16LE(34)
+  const dataSize = buf.readUInt32LE(40)
+  const numSamples = dataSize / (numChannels * (bitsPerSample / 8))
+  const duration = numSamples / sampleRate
+  return { sampleRate, numChannels, bitsPerSample, duration, dataSize }
+}
+
+function calculateRms(buf: Buffer, headerSize = 44, bitsPerSample = 16): number {
+  const numSamples = (buf.length - headerSize) / (bitsPerSample / 8)
+  let sumSq = 0
+  for (let i = 0; i < numSamples; i++) {
+    const sample = buf.readInt16LE(headerSize + i * 2) / 32768
+    sumSq += sample * sample
+  }
+  return Math.sqrt(sumSq / numSamples)
+}
+
+// ── Test ──────────────────────────────────────────────────────────────────────
+
+test.describe('KittenTTS E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    // Pre-set model and voice in localStorage before page load so persisted stores
+    // initialize with KittenTTS (avoids auto-generation starting with wrong model)
+    await page.addInitScript(() => {
+      localStorage.clear()
+      localStorage.setItem('audiobook_model', JSON.stringify('kitten'))
+      localStorage.setItem('audiobook_voice', JSON.stringify('Bella'))
+    })
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    page.on('console', (msg) => console.log(`[PAGE ${msg.type()}] ${msg.text()}`))
+  })
+
+  test('should generate chapter audio with KittenTTS and produce valid non-silent WAV', async ({
+    page,
+  }) => {
+    test.setTimeout(360000) // 6 minutes — model download + inference
+
+    // 1. Upload EPUB (auto-generation starts with KittenTTS+Bella from pre-set localStorage)
+    const epubBuffer = await readFile(SHORT_EPUB)
+    await page.locator('input[type="file"]').setInputFiles({
+      name: 'test-short.epub',
+      mimeType: 'application/epub+zip',
+      buffer: epubBuffer,
+    })
+    await page.waitForSelector('text=Short Test Book', { timeout: 15000 })
+
+    // 2. Wait for auto-generation to complete (triggered on upload for all chapters)
+    //    Wait for progress bars to appear then disappear.
+    await page.waitForSelector('.progress-bar-bg', { timeout: 60000 }).catch(() => {})
+    await page.waitForFunction(() => document.querySelectorAll('.progress-bar-bg').length === 0, {
+      timeout: 300000,
+      polling: 1000,
+    })
+    await page.waitForTimeout(1000)
+
+    // 3. Verify KittenTTS model and Bella voice are active
+    await expect(page.locator('select').first()).toHaveValue('kitten')
+    await expect(page.locator('select option[value="Bella"]')).toBeAttached({ timeout: 5000 })
+
+    // 4. Select only the first chapter and switch format to WAV
+    await page.locator('button:has-text("Deselect All")').click()
+    await page.locator('input[type="checkbox"]').first().check()
+    await page.waitForTimeout(300)
+
+    // Open format dropdown (▾ toggle button) and select WAV
+    await page.locator('button.export-toggle').click()
+    await page.locator('button.format-option', { hasText: 'WAV' }).click()
+    await page.waitForTimeout(300)
+
+    // Capture the chapter text for content proportionality check
+    const chapterText = await page.evaluate(() => {
+      const items = document.querySelectorAll('[data-chapter-text]')
+      return items.length > 0 ? ((items[0] as HTMLElement).dataset.chapterText ?? '') : ''
+    })
+
+    // 5. Export already-generated audio as WAV (no re-generation needed)
+    const [download] = await Promise.all([
+      page.waitForEvent('download', { timeout: 60000 }),
+      page.locator('button.export-main').click(),
+    ])
+
+    // Wait for generation to complete (download fires when done)
+    const downloadPath = await download.path()
+    expect(downloadPath).toBeTruthy()
+
+    const filename = download.suggestedFilename()
+    expect(filename).toMatch(/\.wav$/i)
+
+    // 6. Validate WAV file
+    const buf = await readFile(downloadPath!)
+
+    // 6a. Valid RIFF header
+    const wav = parseWavHeader(buf)
+    expect(wav.sampleRate).toBe(24000)
+    expect(wav.numChannels).toBe(1)
+    expect(wav.bitsPerSample).toBe(16)
+
+    // 6b. Duration > 1 second (non-trivial audio)
+    expect(wav.duration).toBeGreaterThan(1)
+    console.log(`[KittenTTS] Audio duration: ${wav.duration.toFixed(2)}s`)
+
+    // 6c. Not silent — RMS > 0.001
+    const rms = calculateRms(buf)
+    expect(rms).toBeGreaterThan(0.001)
+    console.log(`[KittenTTS] Audio RMS: ${rms.toFixed(5)}`)
+
+    // 6d. Content proportionality: ~100-200 words/minute speech rate
+    //     If we have chapter text, check duration is in a plausible range
+    if (chapterText.length > 0) {
+      const wordCount = chapterText.trim().split(/\s+/).length
+      const minExpectedSec = (wordCount / 200) * 60 // fast speech
+      const maxExpectedSec = (wordCount / 80) * 60 // slow speech
+      console.log(
+        `[KittenTTS] Words: ${wordCount}, expected ${minExpectedSec.toFixed(1)}-${maxExpectedSec.toFixed(1)}s, got ${wav.duration.toFixed(1)}s`
+      )
+      // Loose bounds — just sanity check it's not wildly off
+      expect(wav.duration).toBeGreaterThan(minExpectedSec * 0.3)
+      expect(wav.duration).toBeLessThan(maxExpectedSec * 3)
+    }
+  })
+})

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "kokoro-js": "^1.2.1",
     "onnxruntime-web": "^1.24.1",
     "pdfjs-dist": "^5.4.624",
+    "phonemizer": "^1.2.1",
     "workbox-window": "^7.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       pdfjs-dist:
         specifier: ^5.4.624
         version: 5.4.624
+      phonemizer:
+        specifier: ^1.2.1
+        version: 1.2.1
       workbox-window:
         specifier: ^7.4.0
         version: 7.4.0

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -37,6 +37,7 @@
     voiceLabels,
     lastKokoroVoice,
     lastPiperVoice,
+    lastKittenVoice,
   } from './stores/ttsStore'
   import { audioPlayerStore } from './stores/audioPlayerStore'
   import { currentLibraryBookId } from './stores/libraryStore'
@@ -144,6 +145,19 @@
             }
           })
         }
+      })
+    } else if (model === 'kitten') {
+      import('./lib/kitten/kittenVoices').then(({ listVoices }) => {
+        const voices = listVoices().map((v) => ({ id: v, label: voiceLabels[v] || v }))
+        availableVoices.set(voices)
+        untrack(() => {
+          const last = $lastKittenVoice
+          if (voices.find((v) => v.id === last)) {
+            selectedVoice.set(last)
+          } else if (voices.length > 0) {
+            selectedVoice.set(voices[0].id)
+          }
+        })
       })
     }
   })

--- a/src/lib/kitten/kittenClient.test.ts
+++ b/src/lib/kitten/kittenClient.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { VARIANT_CONFIG, type KittenVariant } from './kittenClient'
+import { ADVANCED_SETTINGS_SCHEMA } from '../types/settings'
+
+describe('KittenTTS variant config', () => {
+  const variants: KittenVariant[] = ['nano', 'micro', 'mini']
+
+  it.each(variants)('variant %s has valid modelUrl and voicesUrl', (variant) => {
+    const cfg = VARIANT_CONFIG[variant]
+    expect(cfg.modelUrl).toMatch(/^https:\/\/huggingface\.co\/KittenML\/kitten-tts/)
+    expect(cfg.voicesUrl).toMatch(/voices\.npz$/)
+    expect(cfg.sizeMb).toBeGreaterThan(0)
+  })
+
+  it('nano is smallest, mini is largest', () => {
+    expect(VARIANT_CONFIG.nano.sizeMb).toBeLessThan(VARIANT_CONFIG.micro.sizeMb)
+    expect(VARIANT_CONFIG.micro.sizeMb).toBeLessThan(VARIANT_CONFIG.mini.sizeMb)
+  })
+
+  it('each variant points to a different model file', () => {
+    const urls = variants.map((v) => VARIANT_CONFIG[v].modelUrl)
+    expect(new Set(urls).size).toBe(3)
+  })
+})
+
+describe('ADVANCED_SETTINGS_SCHEMA kitten entry', () => {
+  const kittenSettings = ADVANCED_SETTINGS_SCHEMA['kitten']
+
+  it('has kitten settings defined', () => {
+    expect(kittenSettings).toBeDefined()
+    expect(kittenSettings.length).toBeGreaterThan(0)
+  })
+
+  it('has modelVariant select with nano/micro/mini options', () => {
+    const variantSetting = kittenSettings.find((s) => s.key === 'modelVariant')
+    expect(variantSetting).toBeDefined()
+    expect(variantSetting!.type).toBe('select')
+    expect(variantSetting!.defaultValue).toBe('micro')
+    const values = variantSetting!.options!.map((o) => o.value)
+    expect(values).toContain('nano')
+    expect(values).toContain('micro')
+    expect(values).toContain('mini')
+  })
+
+  it('has speed slider with valid range', () => {
+    const speedSetting = kittenSettings.find((s) => s.key === 'speed')
+    expect(speedSetting).toBeDefined()
+    expect(speedSetting!.type).toBe('slider')
+    expect(speedSetting!.min).toBeLessThan(1)
+    expect(speedSetting!.max).toBeGreaterThan(1)
+    expect(speedSetting!.defaultValue).toBe(1.0)
+  })
+})

--- a/src/lib/kitten/kittenClient.ts
+++ b/src/lib/kitten/kittenClient.ts
@@ -1,0 +1,280 @@
+/**
+ * KittenTTS browser client
+ * Runs KittenML ONNX models 100% in the browser.
+ *
+ * Pipeline: text → espeak-ng phonemes → token IDs → ONNX → 24kHz WAV
+ */
+
+import logger from '../utils/logger'
+import { fetchAndCache } from '../onnx/modelCache'
+import { MIN_TEXT_LENGTH } from '../audioConstants'
+import { createSilentWav } from '../audioConcat'
+import { KITTEN_VOICE_ALIASES, type KittenVoiceId } from './kittenVoices'
+
+export type { KittenVoiceId } from './kittenVoices'
+export { listVoices } from './kittenVoices'
+
+export type KittenVariant = 'nano' | 'micro' | 'mini'
+
+const VARIANT_CONFIG: Record<
+  KittenVariant,
+  { modelUrl: string; voicesUrl: string; sizeMb: number }
+> = {
+  nano: {
+    modelUrl:
+      'https://huggingface.co/KittenML/kitten-tts-nano-0.2/resolve/main/kitten_tts_nano_v0_2.onnx',
+    voicesUrl: 'https://huggingface.co/KittenML/kitten-tts-nano-0.2/resolve/main/voices.npz',
+    sizeMb: 24,
+  },
+  micro: {
+    modelUrl:
+      'https://huggingface.co/KittenML/kitten-tts-micro-0.8/resolve/main/kitten_tts_micro_v0_8.onnx',
+    voicesUrl: 'https://huggingface.co/KittenML/kitten-tts-micro-0.8/resolve/main/voices.npz',
+    sizeMb: 41,
+  },
+  mini: {
+    modelUrl:
+      'https://huggingface.co/KittenML/kitten-tts-mini-0.1/resolve/main/kitten_tts_mini_v0_1.onnx',
+    voicesUrl: 'https://huggingface.co/KittenML/kitten-tts-mini-0.1/resolve/main/voices.npz',
+    sizeMb: 166,
+  },
+}
+
+export { VARIANT_CONFIG }
+
+// ── TextCleaner symbol map (ported from Python) ───────────────────────────────
+
+const _pad = '$'
+const _punctuation = ';:,.!?¡¿—…\u201c\u00ab\u00bb\u201c\u201d '
+const _letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+const _ipa =
+  'ɑɐɒæɓʙβɔɕçɗɖðʤəɘɚɛɜɝɞɟʄɡɠɢʛɦɧħɥʜɨɪʝɭɬɫɮʟɱɯɰŋɳɲɴøɵɸθœɶʘɹɺɾɻʀʁɽʂʃʈʧʉʊʋⱱʌɣɤʍχʎʏʑʐʒʔʡʕʢǀǁǂǃˈˌːˑʼʴʰʱʲʷˠˤ˞↓↑→↗↘\u0329\u02b0ᵻ'
+
+const SYMBOLS = [_pad, ..._punctuation, ..._letters, ..._ipa]
+const CHAR_TO_IDX: Record<string, number> = Object.fromEntries(SYMBOLS.map((c, i) => [c, i]))
+
+function textClean(phonemes: string): number[] {
+  // Tokenize: split on word chars and punctuation (mirrors Python basic_english_tokenize)
+  const tokens = phonemes.match(/\w+|[^\w\s]/gu) ?? []
+  const joined = tokens.join(' ')
+  const ids: number[] = []
+  for (const ch of joined) {
+    if (ch in CHAR_TO_IDX) ids.push(CHAR_TO_IDX[ch])
+  }
+  return ids
+}
+
+// ── NPY parser (float32 only) ─────────────────────────────────────────────────
+
+function parseNpy(buffer: ArrayBuffer): { shape: number[]; data: Float32Array } {
+  const headerLen = new DataView(buffer).getUint16(8, true)
+  const headerStr = new TextDecoder().decode(new Uint8Array(buffer, 10, headerLen))
+  const shapeMatch = headerStr.match(/'shape':\s*\(([^)]*)\)/)
+  const shape = (shapeMatch?.[1] ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(Number)
+  const dataOffset = 10 + headerLen
+  return { shape, data: new Float32Array(buffer, dataOffset) }
+}
+
+// ── NPZ parser (ZIP of .npy files) ────────────────────────────────────────────
+
+async function parseNpz(
+  buffer: ArrayBuffer
+): Promise<Record<string, { shape: number[]; data: Float32Array }>> {
+  const { default: JSZip } = await import('jszip')
+  const zip = await JSZip.loadAsync(buffer)
+  const arrays: Record<string, { shape: number[]; data: Float32Array }> = {}
+  for (const [name, file] of Object.entries(zip.files)) {
+    if (name.endsWith('.npy')) {
+      const ab = await file.async('arraybuffer')
+      arrays[name.replace(/\.npy$/, '')] = parseNpy(ab)
+    }
+  }
+  return arrays
+}
+
+// ── Float32 → 16-bit PCM WAV ──────────────────────────────────────────────────
+
+function float32ToWav(samples: Float32Array, sampleRate: number): Blob {
+  const numSamples = samples.length
+  const buffer = new ArrayBuffer(44 + numSamples * 2)
+  const view = new DataView(buffer)
+  const write = (offset: number, str: string) => {
+    for (let i = 0; i < str.length; i++) view.setUint8(offset + i, str.charCodeAt(i))
+  }
+  write(0, 'RIFF')
+  view.setUint32(4, 36 + numSamples * 2, true)
+  write(8, 'WAVE')
+  write(12, 'fmt ')
+  view.setUint32(16, 16, true)
+  view.setUint16(20, 1, true) // PCM
+  view.setUint16(22, 1, true) // mono
+  view.setUint32(24, sampleRate, true)
+  view.setUint32(28, sampleRate * 2, true) // byte rate
+  view.setUint16(32, 2, true) // block align
+  view.setUint16(34, 16, true) // bits per sample
+  write(36, 'data')
+  view.setUint32(40, numSamples * 2, true)
+  for (let i = 0; i < numSamples; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i]))
+    view.setInt16(44 + i * 2, s < 0 ? s * 0x8000 : s * 0x7fff, true)
+  }
+  return new Blob([buffer], { type: 'audio/wav' })
+}
+
+// ── Singletons (one cache entry per variant) ──────────────────────────────────
+
+const sessionCache = new Map<KittenVariant, import('onnxruntime-web').InferenceSession>()
+const voicesCache = new Map<
+  KittenVariant,
+  Record<string, { shape: number[]; data: Float32Array }>
+>()
+
+async function getSession(
+  variant: KittenVariant = 'micro',
+  onProgress?: (msg: string) => void
+): Promise<import('onnxruntime-web').InferenceSession> {
+  if (sessionCache.has(variant)) return sessionCache.get(variant)!
+  const { modelUrl, sizeMb } = VARIANT_CONFIG[variant]
+  const ort = await import('onnxruntime-web')
+  // Point WASM files to CDN matching installed version
+  ort.env.wasm.wasmPaths = 'https://cdn.jsdelivr.net/npm/onnxruntime-web@1.24.1/dist/'
+  ort.env.wasm.numThreads = 1
+  ort.env.wasm.proxy = false
+  onProgress?.(`Downloading KittenTTS ${variant} model (~${sizeMb}MB)...`)
+  const res = await fetchAndCache(modelUrl, (loaded, total) => {
+    if (total) onProgress?.(`Downloading model: ${((loaded / total) * 100).toFixed(0)}%`)
+  })
+  const ab = await res.arrayBuffer()
+  onProgress?.('Loading model...')
+  const session = await ort.InferenceSession.create(new Uint8Array(ab), {
+    executionProviders: ['wasm'],
+  })
+  sessionCache.set(variant, session)
+  logger.info(`[KittenTTS] Model loaded (${variant})`)
+  return session
+}
+
+async function getVoices(variant: KittenVariant = 'micro', onProgress?: (msg: string) => void) {
+  if (voicesCache.has(variant)) return voicesCache.get(variant)!
+  const { voicesUrl } = VARIANT_CONFIG[variant]
+  onProgress?.('Downloading voice embeddings...')
+  const res = await fetchAndCache(voicesUrl)
+  const ab = await res.arrayBuffer()
+  const voices = await parseNpz(ab)
+  voicesCache.set(variant, voices)
+  logger.info('[KittenTTS] Voices loaded:', Object.keys(voices))
+  return voices
+}
+
+// ── Text chunking (mirrors Python chunk_text) ─────────────────────────────────
+
+function chunkText(text: string, maxLen = 400): string[] {
+  const sentences = text
+    .split(/[.!?]+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+  const chunks: string[] = []
+  for (const sentence of sentences) {
+    const s = sentence.endsWith(',') ? sentence : sentence + ','
+    if (s.length <= maxLen) {
+      chunks.push(s)
+    } else {
+      const words = s.split(/\s+/)
+      let chunk = ''
+      for (const word of words) {
+        if (chunk.length + word.length + 1 > maxLen && chunk) {
+          chunks.push(chunk.trim() + ',')
+          chunk = word
+        } else {
+          chunk = chunk ? chunk + ' ' + word : word
+        }
+      }
+      if (chunk) chunks.push(chunk.trim() + ',')
+    }
+  }
+  return chunks.length > 0 ? chunks : [text]
+}
+
+// ── Main generate function ────────────────────────────────────────────────────
+
+export type GenerateParams = {
+  text: string
+  voice?: KittenVoiceId
+  speed?: number
+  variant?: KittenVariant
+}
+
+export async function generateVoice(
+  params: GenerateParams,
+  onChunkProgress?: (current: number, total: number) => void,
+  onProgress?: (status: string) => void
+): Promise<Blob> {
+  const { text, voice = 'Bella', speed = 1.0, variant = 'micro' } = params
+
+  if (text.trim().length < MIN_TEXT_LENGTH) {
+    return createSilentWav(0)
+  }
+
+  const [session, voices] = await Promise.all([
+    getSession(variant, onProgress),
+    getVoices(variant, onProgress),
+  ])
+
+  const internalVoice = KITTEN_VOICE_ALIASES[voice] ?? KITTEN_VOICE_ALIASES['Bella']
+  const voiceArr = voices[internalVoice]
+  if (!voiceArr) throw new Error(`Voice '${internalVoice}' not found in voices.npz`)
+
+  const ort = await import('onnxruntime-web')
+  const chunks = chunkText(text)
+  const audioChunks: Float32Array[] = []
+
+  onProgress?.('Generating speech...')
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i]
+    onChunkProgress?.(i + 1, chunks.length)
+
+    // Phonemize
+    const { phonemize } = await import('phonemizer')
+    const phonemeList = await phonemize(chunk, 'en-us')
+    const phonemeStr = phonemeList[0] ?? ''
+
+    // Tokenize
+    const ids = textClean(phonemeStr)
+    const inputIds = [0, ...ids, 0]
+
+    // Style vector: indexed by text length
+    const refId = Math.min(chunk.length, voiceArr.shape[0] - 1)
+    const styleDim = voiceArr.shape[1]
+    const styleVec = voiceArr.data.slice(refId * styleDim, (refId + 1) * styleDim)
+
+    const feeds = {
+      input_ids: new ort.Tensor('int64', BigInt64Array.from(inputIds.map(BigInt)), [
+        1,
+        inputIds.length,
+      ]),
+      style: new ort.Tensor('float32', styleVec, [1, styleDim]),
+      speed: new ort.Tensor('float32', new Float32Array([speed]), [1]),
+    }
+
+    const results = await session.run(feeds)
+    const audio = results['waveform'].data as Float32Array
+    // Trim trailing silence (last 5000 samples as per Python source)
+    audioChunks.push(audio.slice(0, Math.max(0, audio.length - 5000)))
+  }
+
+  // Concatenate all chunks
+  const totalLen = audioChunks.reduce((s, c) => s + c.length, 0)
+  const combined = new Float32Array(totalLen)
+  let offset = 0
+  for (const chunk of audioChunks) {
+    combined.set(chunk, offset)
+    offset += chunk.length
+  }
+
+  return float32ToWav(combined, 24000)
+}

--- a/src/lib/kitten/kittenVoices.ts
+++ b/src/lib/kitten/kittenVoices.ts
@@ -1,0 +1,26 @@
+export type KittenVoiceId =
+  | 'Bella'
+  | 'Jasper'
+  | 'Luna'
+  | 'Bruno'
+  | 'Rosie'
+  | 'Hugo'
+  | 'Kiki'
+  | 'Leo'
+
+export const KITTEN_VOICE_ALIASES: Record<KittenVoiceId, string> = {
+  Bella: 'expr-voice-2-f',
+  Jasper: 'expr-voice-2-m',
+  Luna: 'expr-voice-3-f',
+  Bruno: 'expr-voice-3-m',
+  Rosie: 'expr-voice-4-f',
+  Hugo: 'expr-voice-4-m',
+  Kiki: 'expr-voice-5-f',
+  Leo: 'expr-voice-5-m',
+}
+
+const VOICES: KittenVoiceId[] = ['Bella', 'Jasper', 'Luna', 'Bruno', 'Rosie', 'Hugo', 'Kiki', 'Leo']
+
+export function listVoices(): KittenVoiceId[] {
+  return VOICES
+}

--- a/src/lib/services/generationService.ts
+++ b/src/lib/services/generationService.ts
@@ -1513,12 +1513,12 @@ class GenerationService {
 
                 const blob = await worker.generateVoice({
                   text: segment.text,
-                  modelType: 'piper', // Piper
+                  modelType: effectiveModel as import('../tts/ttsModels').TTSModelType,
                   voice: effectiveVoice,
                   device: currentDevice,
                   language: effectiveLanguage,
                   advancedSettings: currentAdvancedSettings,
-                  // No dtype for Piper
+                  // No dtype for Piper/Kitten
                 })
 
                 const duration = await parseWavDuration(blob)

--- a/src/lib/tts/ttsModels.ts
+++ b/src/lib/tts/ttsModels.ts
@@ -3,7 +3,7 @@
  * Provides a unified interface for different TTS engines
  */
 
-export type TTSModelType = 'kokoro' | 'piper'
+export type TTSModelType = 'kokoro' | 'piper' | 'kitten'
 
 export interface TTSGenerateParams {
   text: string
@@ -85,6 +85,24 @@ export async function getTTSEngine(modelType: TTSModelType): Promise<TTSEngine> 
         },
       }
     }
+    case 'kitten': {
+      const { generateVoice } = await import('../kitten/kittenClient')
+      return {
+        generateVoice: async (params, onChunkProgress, onProgress) => {
+          const kittenSettings = params.advancedSettings?.['kitten'] ?? {}
+          return generateVoice(
+            {
+              text: params.text,
+              voice: params.voice as any,
+              speed: kittenSettings.speed ?? params.speed,
+              variant: kittenSettings.modelVariant ?? 'micro',
+            },
+            onChunkProgress,
+            onProgress
+          )
+        },
+      }
+    }
     default:
       throw new Error(`Unknown TTS model type: ${modelType}`)
   }
@@ -113,6 +131,13 @@ export const TTS_MODELS: TTSModelInfo[] = [
     id: 'piper',
     name: 'Piper TTS',
     description: 'Fast, local neural TTS running in the browser.',
+    requiresDownload: true,
+    supportsOffline: true,
+  },
+  {
+    id: 'kitten',
+    name: 'KittenTTS',
+    description: 'Ultra-lightweight neural TTS (15M params, ~41MB, browser-native).',
     requiresDownload: true,
     supportsOffline: true,
   },

--- a/src/lib/types/settings.ts
+++ b/src/lib/types/settings.ts
@@ -130,6 +130,32 @@ export const ADVANCED_SETTINGS_SCHEMA: ModelAdvancedSettings = {
         'Number of text segments to generate audio for simultaneously. Higher values speed up generation but use more memory.',
     },
   ],
+  kitten: [
+    {
+      key: 'modelVariant',
+      label: 'Model Variant',
+      type: 'select',
+      defaultValue: 'micro',
+      group: 'Model',
+      description: 'nano (~24MB, fastest) · micro (~41MB, balanced) · mini (~166MB, best quality)',
+      options: [
+        { value: 'nano', label: 'Nano (~24MB, fastest)' },
+        { value: 'micro', label: 'Micro (~41MB, balanced)' },
+        { value: 'mini', label: 'Mini (~166MB, best quality)' },
+      ],
+    },
+    {
+      key: 'speed',
+      label: 'Speed',
+      type: 'slider',
+      min: 0.5,
+      max: 2.0,
+      step: 0.1,
+      defaultValue: 1.0,
+      group: 'Audio Characteristics',
+      description: 'Speech rate multiplier.',
+    },
+  ],
   global: [
     {
       key: 'parallelChapters',

--- a/src/stores/ttsStore.test.ts
+++ b/src/stores/ttsStore.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ADVANCED_SETTINGS_SCHEMA } from '../lib/types/settings'
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+Object.defineProperty(globalThis, 'window', { value: globalThis, writable: true })
+
+describe('TTS settings persistence', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    vi.resetModules()
+  })
+
+  it('selectedModel defaults to kokoro', async () => {
+    const { selectedModel } = await import('../stores/ttsStore')
+    let value: string | undefined
+    selectedModel.subscribe((v) => {
+      value = v
+    })()
+    expect(value).toBe('kokoro')
+  })
+
+  it('selectedModel persists kitten across module reload', async () => {
+    localStorageMock.setItem('audiobook_model', JSON.stringify('kitten'))
+    const { selectedModel } = await import('../stores/ttsStore')
+    let value: string | undefined
+    selectedModel.subscribe((v) => {
+      value = v
+    })()
+    expect(value).toBe('kitten')
+  })
+
+  it('lastKittenVoice defaults to Bella', async () => {
+    const { lastKittenVoice } = await import('../stores/ttsStore')
+    let value: string | undefined
+    lastKittenVoice.subscribe((v) => {
+      value = v
+    })()
+    expect(value).toBe('Bella')
+  })
+
+  it('lastKittenVoice persists custom voice', async () => {
+    localStorageMock.setItem('audiobook_voice_kitten', JSON.stringify('Luna'))
+    const { lastKittenVoice } = await import('../stores/ttsStore')
+    let value: string | undefined
+    lastKittenVoice.subscribe((v) => {
+      value = v
+    })()
+    expect(value).toBe('Luna')
+  })
+
+  it('advancedSettings defaults kitten.modelVariant to micro', async () => {
+    const { advancedSettings } = await import('../stores/ttsStore')
+    let value: Record<string, any> | undefined
+    advancedSettings.subscribe((v) => {
+      value = v
+    })()
+    expect(value?.['kitten']?.modelVariant).toBe('micro')
+  })
+
+  it('advancedSettings persists kitten.modelVariant nano', async () => {
+    const stored = { kitten: { modelVariant: 'nano', speed: 1.2 } }
+    localStorageMock.setItem('audiobook_advanced_settings', JSON.stringify(stored))
+    const { advancedSettings } = await import('../stores/ttsStore')
+    let value: Record<string, any> | undefined
+    advancedSettings.subscribe((v) => {
+      value = v
+    })()
+    expect(value?.['kitten']?.modelVariant).toBe('nano')
+    expect(value?.['kitten']?.speed).toBe(1.2)
+  })
+
+  it('advancedSettings merges stored with defaults (missing keys get defaults)', async () => {
+    // Only store modelVariant, speed should get default
+    localStorageMock.setItem(
+      'audiobook_advanced_settings',
+      JSON.stringify({ kitten: { modelVariant: 'mini' } })
+    )
+    const { advancedSettings } = await import('../stores/ttsStore')
+    let value: Record<string, any> | undefined
+    advancedSettings.subscribe((v) => {
+      value = v
+    })()
+    expect(value?.['kitten']?.modelVariant).toBe('mini')
+    expect(value?.['kitten']?.speed).toBe(1.0) // default
+  })
+
+  it('all kitten advanced setting keys match schema', async () => {
+    const { advancedSettings } = await import('../stores/ttsStore')
+    let value: Record<string, any> | undefined
+    advancedSettings.subscribe((v) => {
+      value = v
+    })()
+    const schemaKeys = ADVANCED_SETTINGS_SCHEMA['kitten'].map((s) => s.key)
+    const storeKeys = Object.keys(value?.['kitten'] ?? {})
+    for (const key of schemaKeys) {
+      expect(storeKeys).toContain(key)
+    }
+  })
+})

--- a/src/stores/ttsStore.ts
+++ b/src/stores/ttsStore.ts
@@ -11,7 +11,7 @@ const MODEL_KEY = 'audiobook_model'
 // Type definitions
 export type Quantization = 'fp32' | 'fp16' | 'q8' | 'q4' | 'q4f16'
 export type Device = 'auto' | 'wasm' | 'webgpu' | 'cpu'
-export type TTSModel = 'kokoro' | 'piper'
+export type TTSModel = 'kokoro' | 'piper' | 'kitten'
 
 // Get adaptive defaults based on device capabilities
 // Mobile devices get smaller/faster settings (q4 instead of q8)
@@ -118,6 +118,7 @@ export const lastPiperVoice = persistedWritable<string>(
   'audiobook_voice_piper',
   'en_US-hfc_female-medium'
 )
+export const lastKittenVoice = persistedWritable<string>('audiobook_voice_kitten', 'Bella')
 
 import { ADVANCED_SETTINGS_SCHEMA } from '../lib/types/settings'
 
@@ -215,4 +216,13 @@ export const voiceLabels: Record<string, string> = {
   bm_lewis: '🇬🇧 Lewis (Male British)',
   bm_daniel: '🇬🇧 Daniel (Male British)',
   bm_fable: '🇬🇧 Fable (Male British)',
+  // KittenTTS voices
+  Bella: '🐱 Bella (Female)',
+  Jasper: '🐱 Jasper (Male)',
+  Luna: '🐱 Luna (Female)',
+  Bruno: '🐱 Bruno (Male)',
+  Rosie: '🐱 Rosie (Female)',
+  Hugo: '🐱 Hugo (Male)',
+  Kiki: '🐱 Kiki (Female)',
+  Leo: '🐱 Leo (Male)',
 }


### PR DESCRIPTION
## Summary

Adds [KittenTTS](https://github.com/KittenML/KittenTTS) as a third TTS option running 100% in the browser (no server required).

## What's new

- **3 model variants** selectable in Advanced Settings:
  - Nano (~24MB, fastest) — `kitten-tts-nano-0.2`
  - Micro (~41MB, balanced) — `kitten-tts-micro-0.8` *(default)*
  - Mini (~166MB, best quality) — `kitten-tts-mini-0.1`
- **8 voices**: Bella, Jasper, Luna, Bruno, Rosie, Hugo, Kiki, Leo
- **Speed control** in Advanced Settings (0.5×–2.0×)
- Model and voice selection **persisted** across book refreshes via localStorage

## Pipeline

```
text → chunk_text(400 chars) → espeak-ng phonemize(en-us) →
TextCleaner(char→idx) → [0, ...ids, 0] →
ONNX(input_ids, style[1,256], speed[1]) →
waveform[:-5000] → concat → float32→16bit PCM WAV @ 24kHz
```

## Tests

- **16 new unit tests**: variant config URLs, settings schema, persistence (model/voice/advanced settings survive module reload)
- **E2E test**: uploads EPUB, waits for auto-generation with KittenTTS, exports WAV, validates: RIFF header, 24kHz/mono/16-bit, duration > 1s, RMS > 0.001

## Files changed

| File | Change |
|------|--------|
| `src/lib/kitten/kittenClient.ts` | New — ONNX client (NPY/NPZ parser, phonemizer, WAV output) |
| `src/lib/kitten/kittenVoices.ts` | New — 8 voice definitions + aliases |
| `src/lib/kitten/kittenClient.test.ts` | New — variant config + settings schema tests |
| `src/stores/ttsStore.test.ts` | New — persistence tests |
| `src/lib/types/settings.ts` | Added `kitten` advanced settings (modelVariant, speed) |
| `src/lib/tts/ttsModels.ts` | Added `'kitten'` type + `getTTSEngine` case |
| `src/stores/ttsStore.ts` | Added `'kitten'` to `TTSModel`, `lastKittenVoice` store |
| `src/App.svelte` | Added kitten voice loading effect |
| `src/lib/services/generationService.ts` | Fixed hardcoded `'piper'` → `effectiveModel` |
| `e2e/kittentts.spec.ts` | New — E2E test with WAV validation |