### PR TITLE
feat: Add skip controls and keyboard shortcuts

### DIFF
--- a/src/components/AudioPlayerBar.svelte
+++ b/src/components/AudioPlayerBar.svelte
@@ -69,6 +69,16 @@
     audioService.skipPrevious()
   }
 
+  function handleSkip10Back(e: MouseEvent) {
+    e.stopPropagation()
+    audioService.skip(-10)
+  }
+
+  function handleSkip10Forward(e: MouseEvent) {
+    e.stopPropagation()
+    audioService.skip(10)
+  }
+
   function handleBarClick(e: MouseEvent) {
     if (mode !== 'persistent') return
     const target = e.target as HTMLElement
@@ -154,6 +164,25 @@
     <!-- Controls -->
     <div class="controls">
       <button
+        class="control-btn skip-10"
+        onclick={handleSkip10Back}
+        aria-label="Skip back 10 seconds"
+        title="Skip back 10 seconds"
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path d="M2.5 2v6h6M2.66 15.57a10 10 0 1 0 .57-8.38" />
+        </svg>
+        <span class="skip-label">10</span>
+      </button>
+
+      <button
         class="control-btn"
         onclick={handleSkipBackward}
         aria-label="Previous segment"
@@ -206,6 +235,25 @@
         >
           <path d="M13 19l7-7-7-7M5 19l7-7-7-7" />
         </svg>
+      </button>
+
+      <button
+        class="control-btn skip-10"
+        onclick={handleSkip10Forward}
+        aria-label="Skip forward 10 seconds"
+        title="Skip forward 10 seconds"
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path d="M21.5 2v6h-6M21.34 15.57a10 10 0 1 1-.57-8.38" />
+        </svg>
+        <span class="skip-label">10</span>
       </button>
     </div>
 
@@ -385,6 +433,18 @@
     transition:
       background-color 0.2s,
       transform 0.2s;
+    position: relative;
+  }
+
+  .control-btn.skip-10 {
+    position: relative;
+  }
+
+  .control-btn.skip-10 .skip-label {
+    position: absolute;
+    font-size: 10px;
+    font-weight: bold;
+    pointer-events: none;
   }
 
   .control-btn:hover {

--- a/src/components/TextReader.svelte
+++ b/src/components/TextReader.svelte
@@ -70,6 +70,7 @@
 
   // Settings menu state
   let showSettings = $state(false)
+  let showKeyboardHelp = $state(false)
   let webSpeechVoices = $state<SpeechSynthesisVoice[]>([])
   let piperVoices = $state<Array<{ key: string; name: string; language: string }>>([])
 
@@ -817,6 +818,72 @@
 
     // Load Piper voices
     loadPiperVoices()
+
+    // Keyboard shortcuts
+    const handleKeyPress = (e: KeyboardEvent) => {
+      // Ignore if typing in input or settings open
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement ||
+        showSettings
+      ) {
+        return
+      }
+
+      switch (e.key) {
+        case ' ':
+          e.preventDefault()
+          audioService.togglePlayPause()
+          break
+        case 'ArrowLeft':
+          e.preventDefault()
+          if (e.shiftKey) {
+            audioService.skip(-10)
+          } else {
+            audioService.skipPrevious()
+          }
+          break
+        case 'ArrowRight':
+          e.preventDefault()
+          if (e.shiftKey) {
+            audioService.skip(10)
+          } else {
+            audioService.skipNext()
+          }
+          break
+        case 'ArrowUp': {
+          e.preventDefault()
+          const speedUp = Math.min(audioService.playbackSpeed + 0.1, 3.0)
+          audioService.setSpeed(speedUp)
+          break
+        }
+        case 'ArrowDown': {
+          e.preventDefault()
+          const speedDown = Math.max(audioService.playbackSpeed - 0.1, 0.5)
+          audioService.setSpeed(speedDown)
+          break
+        }
+        case 'f':
+        case 'F':
+          e.preventDefault()
+          if (!document.fullscreenElement) {
+            document.documentElement.requestFullscreen()
+          } else {
+            document.exitFullscreen()
+          }
+          break
+        case '?':
+          e.preventDefault()
+          showKeyboardHelp = !showKeyboardHelp
+          break
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyPress)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyPress)
+    }
   })
 
   async function loadPiperVoices() {

--- a/src/lib/audioPlaybackService.svelte.ts
+++ b/src/lib/audioPlaybackService.svelte.ts
@@ -665,6 +665,29 @@ class AudioPlaybackService {
     return this.voice
   }
 
+  skip(seconds: number) {
+    // For Web Speech, skip segments (approximate)
+    if (this.selectedModel === 'web_speech') {
+      const direction = seconds > 0 ? 1 : -1
+      const segmentsToSkip = Math.ceil(Math.abs(seconds) / 5) // ~5s per segment
+      const newIndex = Math.max(
+        0,
+        Math.min(this.segments.length - 1, this.currentSegmentIndex + direction * segmentsToSkip)
+      )
+      this.playFromSegment(newIndex)
+      return
+    }
+
+    // For audio files, skip time
+    if (this.audio) {
+      const newTime = Math.max(
+        0,
+        Math.min(this.audio.duration || 0, this.audio.currentTime + seconds)
+      )
+      this.audio.currentTime = newTime
+    }
+  }
+
   /**
    * Inject a segment from progressive generation store into audioSegments map
    * This allows playback of progressively generated audio without regeneration


### PR DESCRIPTION
## Summary
Implements core UX improvements for better playback control.

## Features Added
✅ **10s Skip Controls** (#121)
- Skip forward/backward 10 seconds buttons
- Works with all TTS models (Web Speech, Kokoro, Piper)
- Visual feedback with icons and labels

✅ **Keyboard Shortcuts** (#119)
- `Space` - Play/Pause
- `←/→` - Previous/Next segment
- `Shift + ←/→` - Skip 10s back/forward
- `↑/↓` - Speed up/down (0.1x increments)
- `F` - Toggle fullscreen
- `?` - Show keyboard help (coming soon)

## Implementation
- Added `skip(seconds)` method to audioPlaybackService
- Handles Web Speech (segment-based) vs audio files (time-based)
- Keyboard shortcuts ignore input fields and settings menu
- Clean event listener cleanup on unmount

## Testing
- Manual testing with all TTS models
- Skip controls work correctly
- Keyboard shortcuts don't conflict with browser defaults

## Next Steps
- Add keyboard help overlay UI
- Add auto-scroll during playback
- Add progress persistence

Closes #119, #121