### PR TITLE
feat: add progress bar during eBook upload and parsing

### DIFF
--- a/src/lib/parsers/htmlParser.ts
+++ b/src/lib/parsers/htmlParser.ts
@@ -1,4 +1,4 @@
-import type { Book, BookParser, Chapter } from '../types/book'
+import type { Book, BookParser, Chapter, OnParseProgress } from '../types/book'
 import { readFileAsText } from '../fileUtils'
 
 /**
@@ -15,7 +15,7 @@ export class HtmlParser implements BookParser {
     return 'HTML'
   }
 
-  async parse(file: File): Promise<Book> {
+  async parse(file: File, _onProgress?: OnParseProgress): Promise<Book> {
     const html = await readFileAsText(file)
     const parser = new DOMParser()
     const doc = parser.parseFromString(html, 'text/html')

--- a/src/lib/parsers/txtParser.ts
+++ b/src/lib/parsers/txtParser.ts
@@ -1,4 +1,4 @@
-import type { Book, BookParser, Chapter } from '../types/book'
+import type { Book, BookParser, Chapter, OnParseProgress } from '../types/book'
 import { readFileAsText } from '../fileUtils'
 
 /**
@@ -15,7 +15,7 @@ export class TxtParser implements BookParser {
     return 'TXT'
   }
 
-  async parse(file: File): Promise<Book> {
+  async parse(file: File, _onProgress?: OnParseProgress): Promise<Book> {
     const text = await readFileAsText(file)
 
     // Extract metadata from first lines

--- a/src/lib/types/book.ts
+++ b/src/lib/types/book.ts
@@ -22,6 +22,18 @@ export interface Chapter {
 }
 
 /**
+ * Progress callback for book parsing
+ */
+export interface ParseProgress {
+  /** 0–1 fraction of completion */
+  percent: number
+  /** Human-readable description of the current step */
+  step: string
+}
+
+export type OnParseProgress = (progress: ParseProgress) => void
+
+/**
  * Interface that all book parsers must implement
  */
 export interface BookParser {
@@ -29,7 +41,7 @@ export interface BookParser {
   canParse(file: File): Promise<boolean>
 
   /** Parse the file into a Book */
-  parse(file: File): Promise<Book>
+  parse(file: File, onProgress?: OnParseProgress): Promise<Book>
 
   /** Get the format name this parser handles */
   getFormatName(): string


### PR DESCRIPTION
## Summary

Adds a progress bar with step descriptions to the upload/parsing flow so users can see what's happening when loading large eBooks.

### Changes
- Added `ParseProgress` type and optional `onProgress` callback to the `BookParser` interface and `loadBook` function
- EPUB parser reports: reading archive, reading metadata, extracting chapters (per-chapter), loading cover
- PDF parser reports: reading file, loading document, extracting metadata, extracting pages (per-page), detecting chapters
- TXT/HTML parsers accept the callback for interface compliance (they parse fast enough to not need it)
- `UnifiedInput.svelte` shows a slim progress bar with a step description instead of the old static "Parsing eBook..." text

### Design
- Slim 6px track with smooth fill animation
- Uses existing theme variables (`--primary-color`, `--border-color`, `--secondary-text`)
- Accessible: `role="progressbar"` with `aria-valuenow/min/max`
- Non-breaking: the `onProgress` callback is optional everywhere