### PR TITLE
fix: settings page navigation, storage loading, and reader toggle on mobile

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -282,6 +282,11 @@
         return
       }
 
+      if (parsed.view === 'settings') {
+        currentView = 'settings'
+        return
+      }
+
       const bookId = parsed.bookId
       const chapterId = parsed.view === 'reader' ? parsed.chapterId : undefined
 
@@ -348,11 +353,22 @@
 
   {#if currentView === 'landing'}
     <div in:fade class="view-wrapper scrollable">
-      <LandingPage onbookloaded={onBookLoaded} onopensettings={() => (currentView = 'settings')} />
+      <LandingPage
+        onbookloaded={onBookLoaded}
+        onopensettings={() => {
+          currentView = 'settings'
+          location.hash = '#/settings'
+        }}
+      />
     </div>
   {:else if currentView === 'settings'}
     <div in:fade class="view-wrapper scrollable">
-      <SettingsPage onBack={() => (currentView = 'landing')} />
+      <SettingsPage
+        onBack={() => {
+          currentView = 'landing'
+          location.hash = '#/'
+        }}
+      />
     </div>
   {:else if currentView === 'book'}
     <div in:fade class="view-wrapper">
@@ -455,6 +471,7 @@
 
   .view-wrapper.full-height {
     padding: 0;
+    position: relative;
   }
 
   .back-link {
@@ -510,14 +527,15 @@
   }
 
   .mode-btn {
-    padding: 4px 12px;
-    font-size: 0.75rem;
+    padding: 6px 14px;
+    font-size: 0.8rem;
     border: none;
     background: var(--surface-color, #2a2a2a);
     color: var(--secondary-text, #a0a0a0);
     cursor: pointer;
     transition: all 0.15s;
     font-weight: 500;
+    min-height: 36px;
   }
 
   .mode-btn.active {

--- a/src/components/SettingsPage.svelte
+++ b/src/components/SettingsPage.svelte
@@ -393,8 +393,9 @@
     color: var(--secondary-text);
     cursor: pointer;
     font-size: 0.9rem;
-    padding: 8px 0;
+    padding: 8px 16px;
     min-height: 44px;
+    min-width: 44px;
   }
 
   .back-btn:hover {

--- a/src/lib/storageManager.ts
+++ b/src/lib/storageManager.ts
@@ -32,22 +32,27 @@ export async function getStorageInfo(): Promise<StorageInfo> {
   }
 
   try {
-    // Get IndexedDB usage
+    // Get IndexedDB usage — open without version to avoid triggering upgrades.
+    // If the DB doesn't exist yet or stores are missing, we just return zeros.
     const db = await openDB()
+    const storeNames = Array.from(db.objectStoreNames)
 
-    // Count books
-    const booksStore = db.transaction('books', 'readonly').objectStore('books')
-    info.books = await countStore(booksStore)
+    if (storeNames.includes('books')) {
+      const booksStore = db.transaction('books', 'readonly').objectStore('books')
+      info.books = await countStore(booksStore)
+    }
 
-    // Count audio
-    const audioStore = db.transaction('chapterAudio', 'readonly').objectStore('chapterAudio')
-    info.audio = await countStore(audioStore)
+    if (storeNames.includes('chapterAudio')) {
+      const audioStore = db.transaction('chapterAudio', 'readonly').objectStore('chapterAudio')
+      info.audio = await countStore(audioStore)
+    }
 
-    // Count segments
-    const segmentsStore = db
-      .transaction('chapterSegments', 'readonly')
-      .objectStore('chapterSegments')
-    info.segments = await countStore(segmentsStore)
+    if (storeNames.includes('chapterSegments')) {
+      const segmentsStore = db
+        .transaction('chapterSegments', 'readonly')
+        .objectStore('chapterSegments')
+      info.segments = await countStore(segmentsStore)
+    }
 
     db.close()
 
@@ -186,10 +191,11 @@ export async function deleteCachedModel(cacheName: string, cacheKey: string): Pr
  */
 export async function clearLibraryData(): Promise<void> {
   const db = await openDB()
+  const storeNames = Array.from(db.objectStoreNames)
 
-  await clearStore(db, 'books')
-  await clearStore(db, 'chapterAudio')
-  await clearStore(db, 'chapterSegments')
+  if (storeNames.includes('books')) await clearStore(db, 'books')
+  if (storeNames.includes('chapterAudio')) await clearStore(db, 'chapterAudio')
+  if (storeNames.includes('chapterSegments')) await clearStore(db, 'chapterSegments')
 
   db.close()
 }

--- a/src/lib/utils/hashRoutes.ts
+++ b/src/lib/utils/hashRoutes.ts
@@ -22,12 +22,15 @@ export function buildReaderHash(
 
 export type ParsedHash =
   | { view: 'landing' }
+  | { view: 'settings' }
   | { view: 'book'; bookId: BookId }
   | { view: 'reader'; bookId: BookId; chapterId: string }
 
 export function parseHash(hash: string | null | undefined): ParsedHash | null {
   if (!hash || hash === '#/' || hash === '#' || hash === '#/upload' || hash === '#/library')
     return { view: 'landing' }
+
+  if (hash === '#/settings') return { view: 'settings' }
 
   const bookMatch = hash.match(/^#\/book\/([^/]+)(?:\/[^/]+)?$/)
   if (bookMatch) {

--- a/test/hashRoutes.test.ts
+++ b/test/hashRoutes.test.ts
@@ -35,6 +35,10 @@ describe('hashRoutes', () => {
     expect(parseHash(undefined)).toEqual({ view: 'landing' })
   })
 
+  it('parses settings hash', () => {
+    expect(parseHash('#/settings')).toEqual({ view: 'settings' })
+  })
+
   it('returns null for invalid hashes', () => {
     expect(parseHash('#/unknown/route')).toBeNull()
     expect(parseHash('#/book/not-a-number/slug')).toBeNull()


### PR DESCRIPTION
## Summary

Fixes several issues affecting the mobile (Android) experience:

### Settings back button not clickable
The touch target was too narrow — only vertical padding, no horizontal. Added `padding: 8px 16px` and `min-width: 44px` to meet minimum touch target guidelines.

### Storage management stuck on 'Loading storage info'
`storageManager.ts` opened IndexedDB without a version and immediately tried to access object stores (`books`, `chapterAudio`, `chapterSegments`). If the DB hadn't been initialized yet (no books uploaded), those stores don't exist and the transaction throws. Now checks `db.objectStoreNames` before accessing each store, returning zeros for missing stores instead of crashing.

### No URL-based navigation for settings
Added `#/settings` hash route so the browser back button works when navigating to/from settings. Previously only book and reader views had hash routes.

### Reader mode toggle invisible on Android
The toggle used `position: absolute` but the parent `.view-wrapper.full-height` lacked `position: relative`, causing the toggle to position relative to a higher ancestor and potentially get clipped. Also increased button padding and added `min-height: 36px` for better touch targets.