### PR TITLE
fix: format files failing prettier in CI

### DIFF
--- a/e2e/mp3-export-encoding.spec.ts
+++ b/e2e/mp3-export-encoding.spec.ts
@@ -64,7 +64,16 @@ test.describe('MP3 Export Encoding', () => {
     )
 
     // Log all messages for debugging
-    console.log('Console messages after export:', consoleMessages.filter((m) => m.includes('ERROR') || m.includes('Export') || m.includes('mediabunny') || m.includes('download')))
+    console.log(
+      'Console messages after export:',
+      consoleMessages.filter(
+        (m) =>
+          m.includes('ERROR') ||
+          m.includes('Export') ||
+          m.includes('mediabunny') ||
+          m.includes('download')
+      )
+    )
 
     expect(hasEncodingError).toBe(false)
     expect(hasExportFailed).toBe(false)

--- a/src/lib/mediabunnyEncoder.ts
+++ b/src/lib/mediabunnyEncoder.ts
@@ -57,7 +57,10 @@ export async function convertWavToMp3(wavBlob: Blob, bitrate: number = 192): Pro
     })
   } catch (err) {
     logger.error('[mediabunny]', 'Failed to create Input:', err)
-    throw new Error(`Failed to create Mediabunny Input: ${err instanceof Error ? err.message : String(err)}`, { cause: err })
+    throw new Error(
+      `Failed to create Mediabunny Input: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err }
+    )
   }
 
   const output = new Output({
@@ -74,7 +77,10 @@ export async function convertWavToMp3(wavBlob: Blob, bitrate: number = 192): Pro
     })
   } catch (err) {
     logger.error('[mediabunny]', 'Conversion.init failed:', err)
-    throw new Error(`MP3 Conversion.init failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err })
+    throw new Error(
+      `MP3 Conversion.init failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err }
+    )
   }
 
   if (!conversion.isValid) {
@@ -87,7 +93,9 @@ export async function convertWavToMp3(wavBlob: Blob, bitrate: number = 192): Pro
     await conversion.execute()
   } catch (err) {
     logger.error('[mediabunny]', 'conversion.execute() failed:', err)
-    throw new Error(`MP3 encoding failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err })
+    throw new Error(`MP3 encoding failed: ${err instanceof Error ? err.message : String(err)}`, {
+      cause: err,
+    })
   }
 
   const buffer = output.target.buffer
@@ -112,7 +120,10 @@ export async function convertWavToM4b(wavBlob: Blob, bitrate: number = 192): Pro
     })
   } catch (err) {
     logger.error('[mediabunny]', 'Failed to create Input:', err)
-    throw new Error(`Failed to create Mediabunny Input: ${err instanceof Error ? err.message : String(err)}`, { cause: err })
+    throw new Error(
+      `Failed to create Mediabunny Input: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err }
+    )
   }
 
   const output = new Output({
@@ -129,7 +140,10 @@ export async function convertWavToM4b(wavBlob: Blob, bitrate: number = 192): Pro
     })
   } catch (err) {
     logger.error('[mediabunny]', 'Conversion.init failed:', err)
-    throw new Error(`M4B Conversion.init failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err })
+    throw new Error(
+      `M4B Conversion.init failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err }
+    )
   }
 
   if (!conversion.isValid) {
@@ -142,7 +156,9 @@ export async function convertWavToM4b(wavBlob: Blob, bitrate: number = 192): Pro
     await conversion.execute()
   } catch (err) {
     logger.error('[mediabunny]', 'conversion.execute() failed:', err)
-    throw new Error(`M4B encoding failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err })
+    throw new Error(`M4B encoding failed: ${err instanceof Error ? err.message : String(err)}`, {
+      cause: err,
+    })
   }
 
   const buffer = output.target.buffer

--- a/src/lib/services/exportService.ts
+++ b/src/lib/services/exportService.ts
@@ -175,7 +175,10 @@ export async function exportAudio(
       } catch (e) {
         // If incrementalConcatWav fails (e.g., format mismatch between segments),
         // fall back to concatenating raw segment blobs and let Mediabunny handle resampling
-        logger.warn(`[Export] incrementalConcatWav failed for chapter ${ch.id}, trying raw blob fallback:`, e instanceof Error ? e.message : e)
+        logger.warn(
+          `[Export] incrementalConcatWav failed for chapter ${ch.id}, trying raw blob fallback:`,
+          e instanceof Error ? e.message : e
+        )
         try {
           const segments = await getChapterSegments(bookId, ch.id)
           const sortedSegments = [...segments].sort((a, b) => a.index - b.index)

--- a/src/lib/wavMismatch.test.ts
+++ b/src/lib/wavMismatch.test.ts
@@ -9,11 +9,11 @@ import { concatenateAudioChapters, type AudioChapter } from './audioConcat'
 
 // Mock mediabunnyEncoder
 vi.mock('./mediabunnyEncoder', () => ({
-  convertWavToMp3: vi.fn(async (blob: Blob) =>
-    new Blob([await blob.arrayBuffer()], { type: 'audio/mpeg' })
+  convertWavToMp3: vi.fn(
+    async (blob: Blob) => new Blob([await blob.arrayBuffer()], { type: 'audio/mpeg' })
   ),
-  convertWavToM4b: vi.fn(async (blob: Blob) =>
-    new Blob([await blob.arrayBuffer()], { type: 'audio/m4b' })
+  convertWavToM4b: vi.fn(
+    async (blob: Blob) => new Blob([await blob.arrayBuffer()], { type: 'audio/m4b' })
   ),
 }))
 
@@ -108,7 +108,7 @@ describe('WAV segment format mismatch during export', () => {
     // Simulate what Kokoro produces: 24000 Hz mono 16-bit WAV segments
     const seg1 = createWavBlob(24000, 1000) // 1 second
     const seg2 = createWavBlob(24000, 1000) // 1 second
-    const seg3 = createWavBlob(24000, 500)  // 0.5 seconds
+    const seg3 = createWavBlob(24000, 500) // 0.5 seconds
 
     const result = await incrementalConcatWav(3, async (i) => [seg1, seg2, seg3][i])
 

--- a/src/lib/wavUtils.ts
+++ b/src/lib/wavUtils.ts
@@ -198,10 +198,23 @@ export function getAudioDuration(blob: Blob): Promise<number> {
  */
 async function resampleWavBlob(
   blob: Blob,
-  srcInfo: { fmt: { sampleRate: number; numChannels: number; bitsPerSample: number }; dataOffset: number; dataLength: number },
-  targetFmt: { sampleRate: number; numChannels: number; bitsPerSample: number; byteRate: number; blockAlign: number; audioFormat: number }
+  srcInfo: {
+    fmt: { sampleRate: number; numChannels: number; bitsPerSample: number }
+    dataOffset: number
+    dataLength: number
+  },
+  targetFmt: {
+    sampleRate: number
+    numChannels: number
+    bitsPerSample: number
+    byteRate: number
+    blockAlign: number
+    audioFormat: number
+  }
 ): Promise<Blob> {
-  const srcData = new Int16Array(await blob.slice(srcInfo.dataOffset, srcInfo.dataOffset + srcInfo.dataLength).arrayBuffer())
+  const srcData = new Int16Array(
+    await blob.slice(srcInfo.dataOffset, srcInfo.dataOffset + srcInfo.dataLength).arrayBuffer()
+  )
   const srcChannels = srcInfo.fmt.numChannels
   const targetChannels = targetFmt.numChannels
   const srcSampleRate = srcInfo.fmt.sampleRate
@@ -293,7 +306,10 @@ export async function incrementalConcatWav(
       const resampled = await resampleWavBlob(blob, info, referenceFmt)
       const resampledInfo = await parseWavHeaderFromBlob(resampled)
       parts.push(
-        resampled.slice(resampledInfo.dataOffset, resampledInfo.dataOffset + resampledInfo.dataLength)
+        resampled.slice(
+          resampledInfo.dataOffset,
+          resampledInfo.dataOffset + resampledInfo.dataLength
+        )
       )
       totalDataLength += resampledInfo.dataLength
       await new Promise((r) => setTimeout(r, 0))


### PR DESCRIPTION
Fixes CI failure caused by 5 unformatted files:
- e2e/mp3-export-encoding.spec.ts
- src/lib/mediabunnyEncoder.ts
- src/lib/services/exportService.ts
- src/lib/wavMismatch.test.ts
- src/lib/wavUtils.ts