### PR TITLE
fix: convert manualChunks to function form for rolldown/Vite 8

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,10 +48,16 @@ export default defineConfig({
   build: {
     rollupOptions: {
       output: {
-        manualChunks: {
-          'piper-tts': ['onnxruntime-web', '@diffusionstudio/vits-web'],
-          'pdf-parser': ['pdfjs-dist'],
-          zip: ['jszip'],
+        manualChunks(id) {
+          if (id.includes('onnxruntime-web') || id.includes('@diffusionstudio/vits-web')) {
+            return 'piper-tts'
+          }
+          if (id.includes('pdfjs-dist')) {
+            return 'pdf-parser'
+          }
+          if (id.includes('jszip')) {
+            return 'zip'
+          }
         },
       },
     },


### PR DESCRIPTION
## Problem

Both CI (type-check) and Vercel deployment (build) fail because rolldown (Vite 8's bundler) doesn't support the object form of `manualChunks`:

```
TypeError: manualChunks is not a function
```

## Fix

Convert `manualChunks` from object syntax to function syntax, which is the only form rolldown supports:

```ts
// Before (rollup object form — not supported by rolldown)
manualChunks: {
  'piper-tts': ['onnxruntime-web', '@diffusionstudio/vits-web'],
}

// After (function form — works with both rollup and rolldown)
manualChunks(id) {
  if (id.includes('onnxruntime-web') || id.includes('@diffusionstudio/vits-web')) {
    return 'piper-tts'
  }
}
```

## Verification

- `pnpm type-check` ✅
- `pnpm build` ✅ (built in 1.28s, 43 precache entries)
- `pnpm lint` ✅
- `pnpm test` ✅ (579 passed)