### PR TITLE
feat: persist reader-generated segments for reuse

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@huggingface/transformers': 4.0.0-next.6
-
 importers:
 
   .:
@@ -921,11 +918,8 @@ packages:
     resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
     engines: {node: '>=18'}
 
-  '@huggingface/tokenizers@0.1.3':
-    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
-
-  '@huggingface/transformers@4.0.0-next.6':
-    resolution: {integrity: sha512-cMNj6/JG+IB5lPoIg7ZJn1oH608CmvN5/A8U5Xo8lSvr5HtXrUCgzIECjSMi0298MMZGdHHjhXGJ9NJk4Iaqhw==}
+  '@huggingface/transformers@3.8.1':
+    resolution: {integrity: sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1103,6 +1097,10 @@ packages:
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1636,10 +1634,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
-
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -1762,6 +1756,10 @@ packages:
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
   cli-cursor@5.0.0:
@@ -2698,6 +2696,10 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -2745,24 +2747,24 @@ packages:
   onnxruntime-common@1.18.0:
     resolution: {integrity: sha512-lufrSzX6QdKrktAELG5x5VkBpapbCeS3dQwrXbN0eD9rHvU0yAWl7Ztju9FvgAKWvwd/teEKJNj3OwM6eTZh3Q==}
 
-  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
-    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
+  onnxruntime-common@1.21.0:
+    resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
 
-  onnxruntime-common@1.24.3:
-    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
+  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
+    resolution: {integrity: sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==}
 
   onnxruntime-common@1.26.0:
     resolution: {integrity: sha512-qVyMR4lcWgbkc4getFV+GQijsTnbg/siteoqcDwa3sI/LxbrMSNw4ePyvCq/ymdQaRomCA7YuWmhzsswxvymdw==}
 
-  onnxruntime-node@1.24.3:
-    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
+  onnxruntime-node@1.21.0:
+    resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
     os: [win32, darwin, linux]
 
   onnxruntime-web@1.18.0:
     resolution: {integrity: sha512-o1UKj4ABIj1gmG7ae0RKJ3/GT+3yoF0RRpfDfeoe0huzRW4FDRLfbkDETmdFAvnJEXuYDE0YT+hhkia0352StQ==}
 
-  onnxruntime-web@1.25.0-dev.20260303-e7e64dc112:
-    resolution: {integrity: sha512-ZXyMjd56n9bO/62Hnf97xNxPPzu2t4mDSL7PLwQXyIIh/vMq9Fbmv7vALDTVhayBca1t13f3LOEEP2F9gohyvg==}
+  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
+    resolution: {integrity: sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==}
 
   onnxruntime-web@1.26.0:
     resolution: {integrity: sha512-LbRr/8zZt2xilI2smrVQGGKINo0U46i8qJp+UXyMBGfqN7KjnH1BiwCwLwyNIVV4i9CKFv7Sf4PwLKWnT8/bEA==}
@@ -3193,6 +3195,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+    engines: {node: '>=18'}
+
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
@@ -3570,6 +3576,10 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
@@ -4444,14 +4454,11 @@ snapshots:
 
   '@huggingface/jinja@0.5.9': {}
 
-  '@huggingface/tokenizers@0.1.3': {}
-
-  '@huggingface/transformers@4.0.0-next.6':
+  '@huggingface/transformers@3.8.1':
     dependencies:
       '@huggingface/jinja': 0.5.9
-      '@huggingface/tokenizers': 0.1.3
-      onnxruntime-node: 1.24.3
-      onnxruntime-web: 1.25.0-dev.20260303-e7e64dc112
+      onnxruntime-node: 1.21.0
+      onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
       sharp: 0.34.5
 
   '@humanfs/core@0.19.2':
@@ -4567,6 +4574,10 @@ snapshots:
     optional: true
 
   '@isaacs/cliui@9.0.0': {}
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -5050,8 +5061,6 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  adm-zip@0.5.17: {}
-
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -5185,6 +5194,8 @@ snapshots:
   caniuse-lite@1.0.30001793: {}
 
   chai@6.2.2: {}
+
+  chownr@3.0.0: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -6042,7 +6053,7 @@ snapshots:
 
   kokoro-js@1.2.1:
     dependencies:
-      '@huggingface/transformers': 4.0.0-next.6
+      '@huggingface/transformers': 3.8.1
       phonemizer: 1.2.1
 
   leac@0.7.0: {}
@@ -6207,6 +6218,10 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -6242,17 +6257,17 @@ snapshots:
 
   onnxruntime-common@1.18.0: {}
 
-  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
+  onnxruntime-common@1.21.0: {}
 
-  onnxruntime-common@1.24.3: {}
+  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4: {}
 
   onnxruntime-common@1.26.0: {}
 
-  onnxruntime-node@1.24.3:
+  onnxruntime-node@1.21.0:
     dependencies:
-      adm-zip: 0.5.17
       global-agent: 3.0.0
-      onnxruntime-common: 1.24.3
+      onnxruntime-common: 1.21.0
+      tar: 7.5.16
 
   onnxruntime-web@1.18.0:
     dependencies:
@@ -6263,12 +6278,12 @@ snapshots:
       platform: 1.3.6
       protobufjs: 7.6.0
 
-  onnxruntime-web@1.25.0-dev.20260303-e7e64dc112:
+  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
     dependencies:
       flatbuffers: 25.9.23
       guid-typescript: 1.0.9
       long: 5.3.2
-      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
+      onnxruntime-common: 1.22.0-dev.20250409-89f8206ba4
       platform: 1.3.6
       protobufjs: 7.6.0
 
@@ -6812,6 +6827,14 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  tar@7.5.16:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   temp-dir@2.0.0: {}
 
   tempy@0.6.0:
@@ -7230,6 +7253,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  yallist@5.0.0: {}
 
   yaml@1.10.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
+allowBuilds:
+  core-js: true
+  es5-ext: true
+  esbuild: true
+  onnxruntime-node: true
+  protobufjs: true
+  sharp: true
 onlyBuiltDependencies:
   - core-js
   - es5-ext

--- a/src/lib/audioPlaybackService.svelte.ts
+++ b/src/lib/audioPlaybackService.svelte.ts
@@ -5,11 +5,11 @@ import logger from './utils/logger'
 import { audioPlayerStore } from '../stores/audioPlayerStore'
 import { toastStore } from '../stores/toastStore'
 import type { Chapter } from './types/book'
-import { getChapterSegments, getChapterAudio } from './libraryDB'
+import { getChapterSegments, getChapterAudio, saveChapterSegments } from './libraryDB'
 import { segmentHtmlContent } from './services/segmentationService'
 import type { AudioSegment } from './types/audio'
 import { selectPiperVoiceForLanguage, normalizeLanguageCode } from './utils/voiceSelector'
-import { getGeneratedSegment } from '../stores/segmentProgressStore'
+import { getGeneratedSegment, markSegmentGenerated } from '../stores/segmentProgressStore'
 
 interface TextSegment {
   index: number
@@ -1028,6 +1028,28 @@ class AudioPlaybackService {
             if (this.segmentDurations.size === this.segments.length) {
               audioPlayerStore.setChapterDuration(sumKnown)
             }
+          }
+
+          // Persist segment to IndexedDB so chapter generation can reuse it
+          const storeState = get(audioPlayerStore)
+          const currentBookId = storeState.bookId
+          const currentChapterId = storeState.chapterId
+          if (currentBookId && currentChapterId) {
+            const audioSegment: AudioSegment = {
+              id: `${currentChapterId}-seg-${index}`,
+              chapterId: currentChapterId,
+              index,
+              text: segment.text,
+              audioBlob: blob,
+              duration: dur || 0,
+              startTime: 0,
+              voice: this.voice,
+              model: this.selectedModel,
+            }
+            markSegmentGenerated(currentChapterId, audioSegment)
+            saveChapterSegments(currentBookId, currentChapterId, [audioSegment]).catch((err) =>
+              logger.warn('Failed to persist reader segment to IndexedDB', err)
+            )
           }
           return
         } catch (err) {

--- a/src/lib/services/generationService.ts
+++ b/src/lib/services/generationService.ts
@@ -762,8 +762,7 @@ class GenerationService {
             currentQuantization,
             currentDevice,
             currentAdvancedSettings,
-            bookId,
-            true // resume = true
+            bookId
           )
           if (canceled) break
 
@@ -896,8 +895,7 @@ class GenerationService {
     currentQuantization: string,
     currentDevice: string,
     currentAdvancedSettings: Record<string, unknown>,
-    bookId: number,
-    resume = false
+    bookId: number
   ): Promise<boolean> {
     logger.info(`[generateChapters] Segmenting HTML for ${effectiveModel}`, {
       chapterId: ch.id,
@@ -946,8 +944,6 @@ class GenerationService {
       await updateChapterContent(bookId, ch.id, html)
     }
 
-    initChapterSegments(ch.id, textSegments, resume)
-
     // Helper to update the chapter progress message in the UI
     const setProgress = (current: number, total: number, message: string) => {
       throttledProgress.set(ch.id, { current, total, message })
@@ -966,42 +962,38 @@ class GenerationService {
     const batchHandler = new SegmentBatchHandler(bookId, ch.id, batchSize)
 
     // When resuming, load already-generated segments from DB and skip them.
-    // When starting fresh, delete any stale segments from a previous interrupted run.
+    // When starting fresh, auto-detect compatible segments (voice+model match) and reuse them.
     let skipIndices: Set<number> | undefined
-    if (resume && bookId) {
-      setProgress(0, textSegments.length, 'Loading previously generated segments...')
+    if (bookId) {
+      setProgress(0, textSegments.length, 'Checking for existing segments...')
       const { getChapterSegments } = await import('../libraryDB')
       const existing = await getChapterSegments(bookId, ch.id)
       if (existing.length > 0) {
         skipIndices = new Set(existing.map((s) => s.index))
-        // On mobile, only keep lightweight metadata — release blob references immediately
-        // to avoid loading all previously-generated audio blobs into memory at once.
         for (const seg of existing) {
           audioSegments.push({
             id: seg.id,
             chapterId: seg.chapterId,
             index: seg.index,
             text: seg.text,
-            audioBlob: null as unknown as Blob, // blob is safely in IndexedDB
+            audioBlob: null as unknown as Blob,
             duration: seg.duration,
             startTime: seg.startTime,
           })
         }
-        // Let GC reclaim the existing array and its blob references
         existing.length = 0
         setProgress(
           skipIndices.size,
           textSegments.length,
-          `Resuming from segment ${skipIndices.size + 1}/${textSegments.length}...`
+          `Reusing ${skipIndices.size} existing segments, generating remaining...`
         )
         logger.info(
-          `[Resume] Skipping ${skipIndices.size} already-generated segments for chapter ${ch.id}`
+          `[AutoResume] Skipping ${skipIndices.size} existing segments for chapter ${ch.id}`
         )
       }
-    } else if (bookId) {
-      const { deleteChapterSegments } = await import('../libraryDB')
-      await deleteChapterSegments(bookId, ch.id)
     }
+
+    initChapterSegments(ch.id, textSegments, !!skipIndices)
 
     const { failed: failedCount, failedIndices } = await this.processSegmentsWithPriority(
       ch.id,
@@ -1042,6 +1034,8 @@ class GenerationService {
           audioBlob: result.blob as Blob,
           duration: result.duration,
           startTime: 0,
+          voice: effectiveVoice,
+          model: effectiveModel,
         }
         audioSegments.push(segment)
         await batchHandler.addSegment(segment)

--- a/src/lib/types/audio.ts
+++ b/src/lib/types/audio.ts
@@ -8,6 +8,10 @@ export interface AudioSegment {
   startTime: number // Offset from chapter start in seconds
   /** Quality tier: 0=web_speech, 1=low, 2=medium, 3=high/best */
   qualityTier?: number
+  /** TTS voice used to generate this segment */
+  voice?: string
+  /** TTS model used to generate this segment */
+  model?: string
 }
 
 export interface AudioChapterMetadata {


### PR DESCRIPTION
## Summary

Segments generated during text reading (click-to-play) are now saved to IndexedDB and marked in the segment progress store. When full chapter generation runs, it detects and reuses these existing segments instead of re-generating them.

## Changes

- **audioPlaybackService**: persist segments to IndexedDB after on-demand generation
- **generationService**: auto-detect and reuse existing segments (removed explicit resume flag — always checks for compatible segments)
- **AudioSegment type**: added optional `voice` and `model` fields for compatibility tracking
- **pnpm-workspace.yaml**: added `allowBuilds` for native dependencies

## Testing

- `pnpm lint` — 0 errors (109 pre-existing warnings)
- `pnpm test` — 579 passed, 0 failures