### PR TITLE
feat: show model download progress in text reader

### DIFF
--- a/src/components/TextReader.svelte
+++ b/src/components/TextReader.svelte
@@ -21,6 +21,7 @@
   import { saveProgress, loadProgress } from '../stores/progressStore'
   import { loadChapterSegmentProgress } from '../stores/segmentProgressStore'
   import { appSettings } from '../stores/appSettingsStore'
+  import { modelDownloadStore } from '../stores/modelDownloadStore'
   import {
     scheduleUpgradePass,
     cancelUpgrade,
@@ -1171,6 +1172,25 @@
       </div>
     </div>
 
+    <!-- Model Download Progress -->
+    {#if $modelDownloadStore.active}
+      <div class="model-download-banner" transition:fade={{ duration: 200 }}>
+        <div class="download-info">
+          <span class="download-icon">⬇️</span>
+          <span class="download-message">{$modelDownloadStore.message}</span>
+        </div>
+        {#if $modelDownloadStore.percent != null}
+          <div class="download-progress-bar">
+            <div class="download-progress-fill" style="width: {$modelDownloadStore.percent}%"></div>
+          </div>
+        {:else}
+          <div class="download-progress-bar indeterminate">
+            <div class="download-progress-fill"></div>
+          </div>
+        {/if}
+      </div>
+    {/if}
+
     <!-- Text Content -->
     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
     <div
@@ -2001,5 +2021,55 @@
   .shortcut-item span {
     color: var(--text-color);
     font-size: 14px;
+  }
+
+  /* Model Download Banner */
+  .model-download-banner {
+    padding: 8px 16px;
+    background: var(--surface-color, #2a2a2a);
+    border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .download-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--text-color, #e0e0e0);
+  }
+
+  .download-icon {
+    font-size: 14px;
+  }
+
+  .download-progress-bar {
+    height: 4px;
+    background: var(--border-color, rgba(255, 255, 255, 0.1));
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .download-progress-fill {
+    height: 100%;
+    background: var(--primary-color, #3b82f6);
+    border-radius: 2px;
+    transition: width 0.3s ease;
+  }
+
+  .download-progress-bar.indeterminate .download-progress-fill {
+    width: 30%;
+    animation: indeterminate 1.5s ease-in-out infinite;
+  }
+
+  @keyframes indeterminate {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(400%);
+    }
   }
 </style>

--- a/src/lib/audioPlaybackService.svelte.ts
+++ b/src/lib/audioPlaybackService.svelte.ts
@@ -10,6 +10,7 @@ import { segmentHtmlContent } from './services/segmentationService'
 import type { AudioSegment } from './types/audio'
 import { selectPiperVoiceForLanguage, normalizeLanguageCode } from './utils/voiceSelector'
 import { getGeneratedSegment, markSegmentGenerated } from '../stores/segmentProgressStore'
+import { handleModelProgress, clearModelProgress } from '../stores/modelDownloadStore'
 
 interface TextSegment {
   index: number
@@ -992,7 +993,9 @@ class AudioPlaybackService {
             voice: this.voice,
             dtype: this.selectedModel === 'kokoro' ? this.quantization : undefined,
             device: this.device,
+            onProgress: handleModelProgress,
           })
+          clearModelProgress()
 
           // Defensive: revoke old URL if exists (normal flow checks has(index) before calling this method)
           const oldUrl = this.audioSegments.get(index)

--- a/src/stores/modelDownloadStore.ts
+++ b/src/stores/modelDownloadStore.ts
@@ -1,0 +1,22 @@
+import { writable } from 'svelte/store'
+
+export interface ModelDownloadState {
+  active: boolean
+  message: string
+  percent: number | null // null = indeterminate
+}
+
+const initial: ModelDownloadState = { active: false, message: '', percent: null }
+
+export const modelDownloadStore = writable<ModelDownloadState>(initial)
+
+/** Parse progress messages from TTS clients and update the store */
+export function handleModelProgress(msg: string): void {
+  const match = msg.match(/(\d+)%/)
+  const percent = match ? parseInt(match[1], 10) : null
+  modelDownloadStore.set({ active: true, message: msg, percent })
+}
+
+export function clearModelProgress(): void {
+  modelDownloadStore.set(initial)
+}


### PR DESCRIPTION
## Summary

Shows a progress banner in the text reader when a TTS model is being downloaded (first use or cache miss). This gives users feedback during the ~5-10s model download instead of a silent wait.

## Changes

- **src/stores/modelDownloadStore.ts** (new) — simple store with active/message/percent state
- **src/lib/audioPlaybackService.svelte.ts** — pass `onProgress` to `generateVoice()`, clear on completion
- **src/components/TextReader.svelte** — render a progress banner with determinate/indeterminate bar

## How it works

1. User clicks a sentence → `generateVoice()` fires with `onProgress: handleModelProgress`
2. TTS worker emits progress messages like `Downloading model: 45%`
3. `handleModelProgress` parses the percentage and updates the store
4. TextReader subscribes to the store and shows a banner with animated progress bar
5. Once the blob is returned, `clearModelProgress()` hides the banner

## Testing

- `pnpm lint` — 0 errors
- `pnpm test` — 579 passed