### PR TITLE
fix: sanitize Piper text to prevent phoneme ID overflow

### DIFF
--- a/src/lib/piper/piperClient.test.ts
+++ b/src/lib/piper/piperClient.test.ts
@@ -311,3 +311,27 @@ describe('piperClient MIN_TEXT_LENGTH filtering', () => {
     })
   })
 })
+
+describe('Piper text sanitization', () => {
+  beforeEach(() => {
+    vi.mocked(tts.stored).mockResolvedValue([ptVoiceId] as any)
+    vi.mocked(tts.predict).mockReset()
+  })
+
+  it('should sanitize text with digits and uppercase to prevent phoneme ID overflow', async () => {
+    const mockPredict = vi.mocked(tts.predict).mockResolvedValue(makeWav(200))
+    const problematicText = 'O ranking está ordenado pelo número de alojamentos locais por Km2'
+
+    await piperClient.generate(problematicText, { voiceId: ptVoiceId })
+
+    expect(mockPredict).toHaveBeenCalled()
+    const predictedText = mockPredict.mock.calls[0][0]?.text
+    // Should be lowercase
+    expect(predictedText).not.toMatch(/[A-Z]/)
+    // Should not contain raw digits
+    expect(predictedText).not.toMatch(/\d/)
+    // Should still contain the core words
+    expect(predictedText).toContain('ranking')
+    expect(predictedText).toContain('alojamentos')
+  })
+})

--- a/src/lib/piper/piperClient.ts
+++ b/src/lib/piper/piperClient.ts
@@ -342,17 +342,22 @@ export class PiperClient {
       return [createSilentWav(0)]
     }
 
+    // Sanitize text for Piper models with limited phoneme vocabularies.
+    // Lowercase, expand digits, and remove unsupported characters to prevent
+    // "indices element out of data bounds" errors from the ONNX Gather node.
+    const sanitized = this.sanitizeForPiper(text)
+
     try {
       logger.debug(`Calling tts.predict at depth ${depth}`, {
-        textLength: text.length,
-        textPreview: text.substring(0, 100),
+        textLength: sanitized.length,
+        textPreview: sanitized.substring(0, 100),
         voiceId,
       })
 
       const wav = await (
         await getTts()
       ).predict({
-        text,
+        text: sanitized,
         voiceId: voiceId as any,
       })
 
@@ -415,6 +420,36 @@ export class PiperClient {
       }
       return results
     }
+  }
+
+  /**
+   * Sanitize text for Piper models with limited phoneme vocabularies.
+   * Converts to lowercase, expands digits to words, and strips characters
+   * that would produce out-of-range phoneme IDs.
+   */
+  private sanitizeForPiper(text: string): string {
+    // Digit-to-word map (language-neutral; Piper espeak handles pronunciation)
+    const digitWords: Record<string, string> = {
+      '0': 'zero',
+      '1': 'one',
+      '2': 'two',
+      '3': 'three',
+      '4': 'four',
+      '5': 'five',
+      '6': 'six',
+      '7': 'seven',
+      '8': 'eight',
+      '9': 'nine',
+    }
+    let result = text.toLowerCase()
+    // Expand digits to words
+    result = result.replace(/\d/g, (d) => ` ${digitWords[d]} `)
+    // Remove characters outside basic Latin, Latin Extended, and common punctuation
+    // Keep: a-z, accented chars (à-ÿ), spaces, and basic punctuation
+    result = result.replace(/[^\p{L}\p{M}\s.,;:!?'"-]/gu, ' ')
+    // Collapse multiple spaces
+    result = result.replace(/\s+/g, ' ').trim()
+    return result
   }
 
   private splitTextForRetry(text: string): string[] {


### PR DESCRIPTION
## Problem

Piper models with limited vocabularies (e.g. `pt_BR-edresson-low`, 130 phoneme embeddings) crash with:

```
indices element out of data bounds, idx=141 must be within the inclusive range [-130,129]
```

This happens when text contains uppercase letters, digits, or characters that map to phoneme IDs exceeding the model's embedding table size.

## Fix

Added `sanitizeForPiper()` that runs before `tts.predict()`:
- Lowercases text
- Expands digits to words (`2` → `two`)
- Strips characters outside Unicode letter/mark/punctuation ranges
- Collapses whitespace

## Testing

- Added unit test with the exact failing text from the bug report
- `pnpm test` — 580 passed