### PR TITLE
feat: mismatched segment indicator with reprocess button

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,10 @@
+# Domain Context
+
+## Glossary
+
+| Term                  | Definition                                                                                                                                                              |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Segment               | A single sentence-level unit of text within a chapter, mapped 1:1 to an audio blob                                                                                      |
+| Mismatched Segment    | A segment whose stored `voice` or `model` differs from the chapter's current effective TTS settings. Segments with undefined voice/model are NOT considered mismatched. |
+| Effective Voice/Model | The resolved TTS voice and model for a chapter, accounting for chapter overrides, language defaults, and global settings (in that priority order)                       |
+| Reprocess             | Delete mismatched segments from storage and trigger normal generation, which auto-skips existing compatible segments and regenerates only the missing ones              |

--- a/src/components/BookView.svelte
+++ b/src/components/BookView.svelte
@@ -347,6 +347,24 @@
     }
   }
 
+  async function handleReprocess(chapterId: string, mismatchedIndices: number[]) {
+    if (!$book) return
+    const ch = $book.chapters.find((c) => c.id === chapterId)
+    if (!ch) return
+    const { deleteSegmentsByIndices } = await import('../lib/libraryDB')
+    await deleteSegmentsByIndices($book.id!, chapterId, new Set(mismatchedIndices))
+    // Clear mismatched segments from the progress store
+    const { clearSegmentIndices } = await import('../stores/segmentProgressStore')
+    clearSegmentIndices(chapterId, mismatchedIndices)
+    // Trigger generation which will regenerate only missing segments
+    isGenerating = true
+    try {
+      await generationService.resumeChapters([ch])
+    } finally {
+      isGenerating = false
+    }
+  }
+
   async function handleResumeAll() {
     if (!$book) return
     const partialChapters = $book.chapters.filter((c) => {
@@ -802,6 +820,7 @@
             onVoiceChange={handleVoiceChange}
             onLanguageChange={handleLanguageChange}
             onSelectOnly={selectOnlyChapter}
+            onReprocess={handleReprocess}
           />
         {/each}
       </div>

--- a/src/components/ChapterItem.svelte
+++ b/src/components/ChapterItem.svelte
@@ -50,6 +50,7 @@
     onVoiceChange,
     onLanguageChange,
     onSelectOnly,
+    onReprocess,
   } = $props<{
     chapter: Chapter
     book?: Book
@@ -68,6 +69,7 @@
     onVoiceChange?: (chapterId: string, voice: string | undefined) => void
     onLanguageChange?: (chapterId: string, language: string | undefined) => void
     onSelectOnly?: (chapterId: string) => void
+    onReprocess?: (chapterId: string, mismatchedIndices: number[]) => void
   }>()
 
   const numberFormatter = new Intl.NumberFormat()
@@ -170,6 +172,21 @@
     }
     // 4. Global toolbar fallback
     return $selectedVoice
+  })
+
+  // Detect mismatched segments (voice/model differs from current effective settings)
+  let mismatchedIndices = $derived.by(() => {
+    const progress = chapterSegmentProgress
+    if (!progress) return []
+    const indices: number[] = []
+    for (const [idx, seg] of progress.generatedSegments) {
+      const voiceMismatch = seg.voice != null && seg.voice !== effectiveVoice
+      const modelMismatch = seg.model != null && seg.model !== effectiveModel
+      if (voiceMismatch || modelMismatch) {
+        indices.push(idx)
+      }
+    }
+    return indices
   })
 
   function copy() {
@@ -475,6 +492,25 @@
           <option value={fmt.value}>{fmt.label}</option>
         {/each}
       </select>
+    </div>
+  {/if}
+
+  {#if mismatchedIndices.length > 0 && (status === 'done' || isDoneWithoutAudio)}
+    <div class="mismatch-warning">
+      <span class="mismatch-text">
+        ⚠️ {mismatchedIndices.length}/{chapterSegmentProgress?.totalSegments ?? 0} segments use a different
+        voice/model
+      </span>
+      {#if onReprocess}
+        <button
+          class="action-btn small reprocess-btn"
+          onclick={() => onReprocess(chapter.id, mismatchedIndices)}
+          title="Regenerate segments that don't match current voice/model settings"
+          aria-label="Regenerate mismatched segments"
+        >
+          🔄 Regenerate mismatched
+        </button>
+      {/if}
     </div>
   {/if}
 
@@ -1351,5 +1387,33 @@
       font-size: 0.75rem;
       padding: 4px 8px;
     }
+  }
+
+  .mismatch-warning {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    margin-top: 8px;
+    background: rgba(234, 179, 8, 0.1);
+    border: 1px solid rgba(234, 179, 8, 0.3);
+    border-radius: 8px;
+    flex-wrap: wrap;
+  }
+
+  .mismatch-text {
+    font-size: 0.82rem;
+    color: var(--text-color);
+    opacity: 0.9;
+  }
+
+  .reprocess-btn {
+    background: rgba(234, 179, 8, 0.15);
+    border-color: rgba(234, 179, 8, 0.4);
+    color: var(--text-color);
+  }
+
+  .reprocess-btn:hover {
+    background: rgba(234, 179, 8, 0.25);
   }
 </style>

--- a/src/lib/libraryDB.ts
+++ b/src/lib/libraryDB.ts
@@ -898,6 +898,44 @@ export async function deleteChapterSegments(bookId: number, chapterId: string): 
 }
 
 /**
+ * Delete specific segments by their indices from a chapter.
+ * Used to remove mismatched segments before regeneration.
+ */
+export async function deleteSegmentsByIndices(
+  bookId: number,
+  chapterId: string,
+  indices: Set<number>
+): Promise<void> {
+  const db = await openDB()
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(SEGMENT_STORE_NAME, 'readwrite')
+    const store = transaction.objectStore(SEGMENT_STORE_NAME)
+    const index = store.index('chapterId')
+    const request = index.openCursor(IDBKeyRange.only([bookId, chapterId]))
+
+    request.onsuccess = () => {
+      const cursor = request.result
+      if (cursor) {
+        if (indices.has(cursor.value.index)) {
+          cursor.delete()
+        }
+        cursor.continue()
+      }
+    }
+
+    transaction.oncomplete = () => {
+      db.close()
+      resolve()
+    }
+    transaction.onerror = () => {
+      db.close()
+      reject(new Error('Failed to delete segments by indices'))
+    }
+  })
+}
+
+/**
  * Get a single audio segment by its index (loads only one blob at a time).
  * Used for incremental concatenation on memory-constrained devices.
  */

--- a/src/stores/segmentProgressStore.ts
+++ b/src/stores/segmentProgressStore.ts
@@ -108,6 +108,31 @@ export function markChapterGenerationComplete(chapterId: string) {
 }
 
 /**
+ * Remove specific segment indices from a chapter's progress.
+ * Used when reprocessing mismatched segments — clears them so generation recreates them.
+ */
+export function clearSegmentIndices(chapterId: string, indices: number[]) {
+  segmentProgress.update((map) => {
+    const newMap = new Map(map)
+    const progress = newMap.get(chapterId)
+    if (progress) {
+      const newGenerated = new Set(progress.generatedIndices)
+      const newSegments = new Map(progress.generatedSegments)
+      for (const idx of indices) {
+        newGenerated.delete(idx)
+        newSegments.delete(idx)
+      }
+      newMap.set(chapterId, {
+        ...progress,
+        generatedIndices: newGenerated,
+        generatedSegments: newSegments,
+      })
+    }
+    return newMap
+  })
+}
+
+/**
  * Mark a chapter as generating without clearing existing segment progress.
  * Used when resuming a partially-generated chapter.
  */


### PR DESCRIPTION
## Summary

When a chapter has segments generated with a different voice/model than the current settings, the chapter item now shows a warning with a count and a 'Regenerate mismatched' button.

## Design Decisions (via grill-with-docs)

- **Mismatched Segment**: a segment whose stored `voice` or `model` explicitly differs from the chapter's current effective settings. Segments with `undefined` fields are NOT flagged.
- **Computation**: `$derived` in ChapterItem (UI concern, no new store needed)
- **Reprocess flow**: delete mismatched segments from IndexedDB → clear from progress store → trigger normal generation (reuses existing auto-resume logic)
- **UI**: inline warning + button, shown only when status is 'done' and mismatches exist

## Changes

- **ChapterItem.svelte** — mismatch detection derived, warning UI with reprocess button
- **BookView.svelte** — `handleReprocess` handler wired to ChapterItem
- **segmentProgressStore.ts** — `clearSegmentIndices()` to remove specific indices
- **libraryDB.ts** — `deleteSegmentsByIndices()` for targeted segment removal
- **CONTEXT.md** — domain glossary (Segment, Mismatched Segment, Effective Voice/Model, Reprocess)

## Testing

- `pnpm lint` — 0 errors
- `pnpm test` — 580 passed