### PR TITLE
feat: M4B chapter markers (Nero chpl atom)

### DIFF
--- a/src/lib/audioConcat.ts
+++ b/src/lib/audioConcat.ts
@@ -281,9 +281,21 @@ export async function concatenateAudioChapters(
         outputBlob = await mediabunnyConvertWavToMp3(wavBlob, bitrate)
         break
       case 'm4b':
-      case 'mp4':
+      case 'mp4': {
         outputBlob = await convertWavToM4b(wavBlob, bitrate)
+        // Inject Nero chapter markers if we have multiple chapters with durations
+        if (chapters.length > 1) {
+          const { injectChapterMarkers } = await import('./m4bChapters')
+          let startMs = 0
+          const markers = chapters.map((ch) => {
+            const marker = { title: ch.title, startTimeMs: startMs }
+            startMs += (ch.duration || 0) * 1000
+            return marker
+          })
+          outputBlob = await injectChapterMarkers(outputBlob, markers)
+        }
         break
+      }
       case 'wav':
       default:
         outputBlob = wavBlob

--- a/src/lib/m4bChapters.test.ts
+++ b/src/lib/m4bChapters.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { injectChapterMarkers, type ChapterMarker } from './m4bChapters'
+
+/**
+ * Test for M4B chapter marker injection (issue #157)
+ */
+describe('m4bChapters', () => {
+  // Create a minimal valid MP4 with just ftyp + moov atoms
+  function createMinimalMp4(): Blob {
+    const buf = new Uint8Array(28)
+    const view = new DataView(buf.buffer)
+    // ftyp atom (20 bytes)
+    view.setUint32(0, 20) // size
+    buf.set(new TextEncoder().encode('ftyp'), 4)
+    buf.set(new TextEncoder().encode('M4A '), 8)
+    // moov atom (8 bytes, empty)
+    view.setUint32(20, 8) // size
+    buf.set(new TextEncoder().encode('moov'), 24)
+    return new Blob([buf], { type: 'audio/m4b' })
+  }
+
+  it('should inject chapter markers into M4B', async () => {
+    const m4b = createMinimalMp4()
+    const chapters: ChapterMarker[] = [
+      { title: 'Chapter 1', startTimeMs: 0 },
+      { title: 'Chapter 2', startTimeMs: 60000 },
+      { title: 'Chapter 3', startTimeMs: 120000 },
+    ]
+
+    const result = await injectChapterMarkers(m4b, chapters)
+
+    // Result should be larger than input (markers added)
+    expect(result.size).toBeGreaterThan(m4b.size)
+
+    // Verify the result contains 'chpl' and 'udta' atoms
+    const data = new Uint8Array(await result.arrayBuffer())
+    const text = new TextDecoder().decode(data)
+    expect(text).toContain('udta')
+    expect(text).toContain('chpl')
+    // Verify chapter titles are in the output
+    expect(text).toContain('Chapter 1')
+    expect(text).toContain('Chapter 2')
+    expect(text).toContain('Chapter 3')
+  })
+
+  it('should return unchanged blob when no chapters provided', async () => {
+    const m4b = createMinimalMp4()
+    const result = await injectChapterMarkers(m4b, [])
+    expect(result.size).toBe(m4b.size)
+  })
+
+  it('should handle missing moov atom gracefully', async () => {
+    const noMoov = new Blob([new Uint8Array(100)], { type: 'audio/m4b' })
+    const chapters: ChapterMarker[] = [{ title: 'Ch1', startTimeMs: 0 }]
+    const result = await injectChapterMarkers(noMoov, chapters)
+    // Should return unchanged
+    expect(result.size).toBe(noMoov.size)
+  })
+
+  it('should truncate titles longer than 255 bytes', async () => {
+    const m4b = createMinimalMp4()
+    const longTitle = 'A'.repeat(300)
+    const chapters: ChapterMarker[] = [{ title: longTitle, startTimeMs: 0 }]
+
+    const result = await injectChapterMarkers(m4b, chapters)
+    const data = new Uint8Array(await result.arrayBuffer())
+    const text = new TextDecoder().decode(data)
+
+    // Title should be truncated to 255 chars
+    expect(text).not.toContain(longTitle)
+    expect(text).toContain('A'.repeat(255))
+  })
+})

--- a/src/lib/m4bChapters.ts
+++ b/src/lib/m4bChapters.ts
@@ -1,0 +1,147 @@
+/**
+ * Inject Nero-style chapter markers (chpl atom) into an M4B/MP4 file.
+ *
+ * The chpl atom is placed inside a udta atom within the moov atom.
+ * Format:
+ *   - 4 bytes: atom size (big-endian)
+ *   - 4 bytes: 'chpl'
+ *   - 1 byte: version (0)
+ *   - 3 bytes: flags (0)
+ *   - 4 bytes: reserved (0)
+ *   - 1 byte: chapter count
+ *   - For each chapter:
+ *     - 8 bytes: start time in 100ns units (big-endian int64)
+ *     - 1 byte: title length
+ *     - N bytes: title (UTF-8)
+ */
+
+import logger from './utils/logger'
+
+export interface ChapterMarker {
+  title: string
+  startTimeMs: number
+}
+
+/**
+ * Inject chapter markers into an M4B blob.
+ * Returns a new Blob with the chpl atom added inside moov/udta.
+ */
+export async function injectChapterMarkers(
+  m4bBlob: Blob,
+  chapters: ChapterMarker[]
+): Promise<Blob> {
+  if (chapters.length === 0) return m4bBlob
+
+  const buffer = await m4bBlob.arrayBuffer()
+  const data = new Uint8Array(buffer)
+
+  // Find moov atom
+  const moovOffset = findAtom(data, 'moov', 0)
+  if (moovOffset === -1) {
+    logger.warn('[chpl] No moov atom found, returning without chapter markers')
+    return m4bBlob
+  }
+
+  const moovSize = readUint32(data, moovOffset)
+  const moovEnd = moovOffset + moovSize
+
+  // Build the chpl atom
+  const chplData = buildChplAtom(chapters)
+
+  // Build udta atom wrapping chpl
+  const udtaSize = 8 + chplData.byteLength
+  const udtaAtom = new Uint8Array(udtaSize)
+  const udtaView = new DataView(udtaAtom.buffer)
+  udtaView.setUint32(0, udtaSize)
+  udtaAtom.set(new TextEncoder().encode('udta'), 4)
+  udtaAtom.set(chplData, 8)
+
+  // Insert udta at end of moov (before moov's end)
+  // We need to expand moov's size by udtaSize
+  const before = data.slice(0, moovEnd)
+  const after = data.slice(moovEnd)
+
+  // Update moov size
+  const newMoovSize = moovSize + udtaSize
+  const result = new Uint8Array(before.length + udtaSize + after.length)
+  result.set(before, 0)
+  result.set(udtaAtom, moovEnd)
+  result.set(after, moovEnd + udtaSize)
+
+  // Patch moov size in place
+  const resultView = new DataView(result.buffer)
+  resultView.setUint32(moovOffset, newMoovSize)
+
+  logger.info(`[chpl] Injected ${chapters.length} chapter markers into M4B`)
+  return new Blob([result], { type: 'audio/m4b' })
+}
+
+function buildChplAtom(chapters: ChapterMarker[]): Uint8Array {
+  // Calculate size
+  let titlesSize = 0
+  const encoder = new TextEncoder()
+  const encodedTitles = chapters.map((ch) => {
+    const title = encoder.encode(ch.title.slice(0, 255))
+    titlesSize += 8 + 1 + title.byteLength // timestamp + titleLen + title
+    return title
+  })
+
+  const atomSize = 8 + 4 + 4 + 1 + titlesSize // header + version+flags + reserved + count + entries
+  const buf = new Uint8Array(atomSize)
+  const view = new DataView(buf.buffer)
+
+  // Atom header
+  view.setUint32(0, atomSize)
+  buf.set(encoder.encode('chpl'), 4)
+
+  // Version (1 byte) + flags (3 bytes)
+  view.setUint32(8, 0)
+  // Reserved
+  view.setUint32(12, 0)
+  // Chapter count
+  buf[16] = chapters.length
+
+  let offset = 17
+  for (let i = 0; i < chapters.length; i++) {
+    // Start time in 100ns units (ms * 10000)
+    const time100ns = BigInt(chapters[i].startTimeMs) * 10000n
+    view.setBigUint64(offset, time100ns)
+    offset += 8
+    // Title length + title
+    buf[offset] = encodedTitles[i].byteLength
+    offset += 1
+    buf.set(encodedTitles[i], offset)
+    offset += encodedTitles[i].byteLength
+  }
+
+  return buf
+}
+
+function findAtom(data: Uint8Array, name: string, start: number): number {
+  const nameBytes = new TextEncoder().encode(name)
+  let offset = start
+  while (offset + 8 <= data.length) {
+    const size = readUint32(data, offset)
+    if (size < 8) break // Invalid atom
+    if (
+      data[offset + 4] === nameBytes[0] &&
+      data[offset + 5] === nameBytes[1] &&
+      data[offset + 6] === nameBytes[2] &&
+      data[offset + 7] === nameBytes[3]
+    ) {
+      return offset
+    }
+    offset += size
+  }
+  return -1
+}
+
+function readUint32(data: Uint8Array, offset: number): number {
+  return (
+    ((data[offset] << 24) |
+      (data[offset + 1] << 16) |
+      (data[offset + 2] << 8) |
+      data[offset + 3]) >>>
+    0
+  )
+}

--- a/src/lib/services/exportService.ts
+++ b/src/lib/services/exportService.ts
@@ -167,10 +167,12 @@ export async function exportAudio(
           const chapterBlob = await incrementalConcatWav(sortedSegments.length, async (index) => {
             return sortedSegments[index]?.audioBlob ?? null
           })
+          const chapterDuration = sortedSegments.reduce((sum, s) => sum + (s.duration || 0), 0)
           audioChapters.push({
             id: ch.id,
             title: ch.title,
             blob: chapterBlob,
+            duration: chapterDuration,
           })
         }
       } catch (e) {


### PR DESCRIPTION
## Summary

Injects Nero-style chapter markers into M4B exports when exporting multiple chapters. Audiobook players that support the `chpl` atom will show chapter navigation.

## How it works

1. Export service computes chapter durations by summing segment durations from IndexedDB
2. After Mediabunny produces the M4B (AAC/MP4), `injectChapterMarkers()` inserts a `udta/chpl` atom inside the `moov` atom
3. Each chapter gets a start timestamp and title

## Player compatibility

The Nero `chpl` format is supported by: VLC, Smart Audiobook Player, Apple Books, BookPlayer, Plex.

## Changes

- **src/lib/m4bChapters.ts** (new) — builds and injects chpl atom
- **src/lib/audioConcat.ts** — calls `injectChapterMarkers` after M4B encoding
- **src/lib/services/exportService.ts** — computes chapter durations from segments
- **src/lib/m4bChapters.test.ts** (new) — 4 tests

## Testing

- `pnpm lint` — 0 errors
- `pnpm test` — 608 passed

Closes #157